### PR TITLE
Add simple and verbose logging for capturing requests and responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Logs
+*.log

--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -41,6 +41,7 @@ module FHIR
   def initialize(baseServiceUrl)
     @baseServiceUrl = baseServiceUrl
     @use_format_param = false
+    $LOG.info "Initializing client with #{@baseServiceUrl}"
   end
 
   #
@@ -133,6 +134,7 @@ module FHIR
   end
 
   def parse_reply(klass, format, response)
+    $LOG.info "Parsing response with {klass: #{klass}, format: #{format}, code: #{response.code}}."
     FHIR::ResourceAddress.parse_resource(response, format, klass) if [200, 201].include? response.code
   end
 
@@ -199,22 +201,34 @@ module FHIR
 
     def get(path, headers)
       puts "GETTING: #{base_path(path)}#{path}"
-      RestClient.get(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers){ |response, request, result| FHIR::ClientReply.new(request, response) }
+      RestClient.get(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers){ |response, request, result|
+        $LOG.info "GET - Request: #{request.to_json}, Response: #{response}"
+        FHIR::ClientReply.new(request, response)
+      }
     end
 
     def post(path, resource, headers)
       puts "POSTING: #{base_path(path)}#{path}"
-      RestClient.post(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result| FHIR::ClientReply.new(request, response) }
+      RestClient.post(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result|
+        $LOG.info "POST - Request: #{request.to_json}, Response: #{response}"
+        FHIR::ClientReply.new(request, response)
+      }
     end
 
     def put(path, resource, headers)
       puts "PUTTING: #{base_path(path)}#{path}"
-      RestClient.put(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result| FHIR::ClientReply.new(request, response) }
+      RestClient.put(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result|
+        $LOG.info "PUT - Request: #{request.to_json}, Response: #{response}"
+        FHIR::ClientReply.new(request, response)
+      }
     end
 
     def delete(path, headers)
       puts "DELETING: #{base_path(path)}#{path}"
-      RestClient.delete(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers) { |response, request, result| FHIR::ClientReply.new(request, response) }
+      RestClient.delete(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers) { |response, request, result|
+        $LOG.info "Delete - Request: #{request.to_json}, Response: #{response}"
+        FHIR::ClientReply.new(request, response)
+      }
     end
 
   end

--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -202,7 +202,7 @@ module FHIR
     def get(path, headers)
       puts "GETTING: #{base_path(path)}#{path}"
       RestClient.get(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers){ |response, request, result|
-        $LOG.info "GET - Request: #{request.to_json}, Response: #{response}"
+        $LOG.info "GET - Request: #{request.to_json}, Response: #{response.force_encoding("UTF-8")}"
         FHIR::ClientReply.new(request, response)
       }
     end
@@ -210,7 +210,7 @@ module FHIR
     def post(path, resource, headers)
       puts "POSTING: #{base_path(path)}#{path}"
       RestClient.post(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result|
-        $LOG.info "POST - Request: #{request.to_json}, Response: #{response}"
+        $LOG.info "POST - Request: #{request.to_json}, Response: #{response.force_encoding("UTF-8")}"
         FHIR::ClientReply.new(request, response)
       }
     end
@@ -218,7 +218,7 @@ module FHIR
     def put(path, resource, headers)
       puts "PUTTING: #{base_path(path)}#{path}"
       RestClient.put(URI(URI.escape("#{base_path(path)}#{path}")).to_s, resource.to_xml, headers) { |response, request, result|
-        $LOG.info "PUT - Request: #{request.to_json}, Response: #{response}"
+        $LOG.info "PUT - Request: #{request.to_json}, Response: #{response.force_encoding("UTF-8")}"
         FHIR::ClientReply.new(request, response)
       }
     end
@@ -226,7 +226,7 @@ module FHIR
     def delete(path, headers)
       puts "DELETING: #{base_path(path)}#{path}"
       RestClient.delete(URI(URI.escape("#{base_path(path)}#{path}")).to_s, headers) { |response, request, result|
-        $LOG.info "Delete - Request: #{request.to_json}, Response: #{response}"
+        $LOG.info "Delete - Request: #{request.to_json}, Response: #{response.force_encoding("UTF-8")}"
         FHIR::ClientReply.new(request, response)
       }
     end

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -6,6 +6,10 @@ require 'nokogiri'
 require 'fhir_model'
 require 'rest_client'
 
+# Simple and verbose loggers
+RestClient.log = Logger.new("fhir_client.log", 10, 1024000)
+$LOG = Logger.new("fhir_client_verbose.log", 10, 1024000)
+
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 Dir.glob(File.join(root, 'lib','sections','**','*.rb')).each do |file|
   require file


### PR DESCRIPTION
- Added simple RestClient logging and verbose custom logging for capturing request and response values
- currently enabled by default, and outputs to ```fhir_client.log``` and ```fhir_client_verbose.log``` files (with 10 file history)