### PR TITLE
Oauth updates

### DIFF
--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -69,19 +69,27 @@ module FHIR
     @client = RestClient
   end
 
+  # Set the client to use Bearer Token Authentication
+  def set_bearer_token(token)
+    $LOG.info "Configuring the client to use Bearer Token authentication."
+    value = "Bearer #{token}"
+    @security_headers = { 'Authorization' => value }
+    @use_oauth2_auth = false
+    @use_basic_auth = true
+    @client = RestClient
+  end
+
   # Set the client to use OpenID Connect OAuth2 Authentication
   # client -- client id
   # secret -- client secret
-  # baseUrl -- URL of the Authentication server (not the FHIR server endpoint)
-  # authorizePath -- path (appended to baseUrl) of authorization endpoint
-  # tokenPath -- path (appended to baseUrl) of token endpoint
-  def set_oauth2_auth(client,secret,baseUrl,authorizePath='/authorize',tokenPath='/token')
+  # authorizePath -- absolute path of authorization endpoint
+  # tokenPath -- absolute path of token endpoint
+  def set_oauth2_auth(client,secret,authorizePath,tokenPath)
     $LOG.info "Configuring the client to use OpenID Connect OAuth2 authentication."
     @use_oauth2_auth = true
     @use_basic_auth = false
     @security_headers = {}
     options = {
-      :site => baseUrl,
       :authorize_url => authorizePath,
       :token_url => tokenPath,
       :raise_errors => false
@@ -117,7 +125,6 @@ module FHIR
   #   </security>
   def get_oauth2_metadata_from_conformance
     options = {
-      :site => nil,
       :authorize_url => nil,
       :token_url => nil
     }
@@ -130,14 +137,12 @@ module FHIR
         rest.security.service.each do |service|
           service.coding.each do |coding|
             if coding.code == 'OAuth2'
-              rest.security.extension.each do |ext|
-                case ext.url
+              rest.security.extension.where({url: "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"}).first.extension.each do |ext|
+                case ext.absolute_url
                 when authorize_extension
-                  options[:site] = ext.value[:value].split('/')[0..-2].join('/')
-                  options[:authorize_url] = ext.value[:value].split('/').last
+                  options[:authorize_url] = ext.value[:value]
                 when token_extension
-                  options[:site] = ext.value[:value].split('/')[0..-2].join('/')
-                  options[:token_url] = ext.value[:value].split('/').last
+                  options[:token_url] = ext.value[:value]
                 end
               end
             end
@@ -145,10 +150,10 @@ module FHIR
         end
       end
     rescue Exception => e
-      $LOG.error 'Failed to location SMART-on-FHIR OAuth2 Security Extensions.'
+      $LOG.error 'Failed to locate SMART-on-FHIR OAuth2 Security Extensions.'
     end
     options.delete_if{|k,v|v.nil?}
-    options.clear if options.keys.size!=3
+    options.clear if options.keys.size!=2
     options
   end
 

--- a/lib/model/client_reply.rb
+++ b/lib/model/client_reply.rb
@@ -27,7 +27,7 @@ module FHIR
 
     def id
       return nil if @resource_class.nil?
-      (self_link || @request[:url]) =~ %r{(?<=#{@resource_class.name.demodulize}\/)(\w+)}
+      (self_link || @request[:url]) =~ %r{(?<=#{@resource_class.name.demodulize}\/)([^\/]+)}
       $1
     end
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -29,7 +29,7 @@ namespace :fhir do
     if options.empty?
       puts 'This server does not support the expected OAuth2 extensions.'
     else
-      client.set_oauth2_auth(client_id,client_secret,options[:site],options[:authorize_url],options[:token_url])
+      client.set_oauth2_auth(client_id,client_secret,options[:authorize_url],options[:token_url])
       reply = client.read_feed(FHIR::Patient)
       puts reply.body
     end


### PR DESCRIPTION
Issue: SMART on FHIR changed their OAuth2 Structure Definition
Fix: changed format looked for in metadata in `ClientInterface#get_oauth2_metadata_for_conformance`

Issue: authorize and token endpoints could be on different servers
Fix: instead of passing in a `site` URL and `authorize` and `token` URLs relative to that `site` variable, pass in `authorize` and `token` as absolute URLs.

Issue: Need to be able to use bearer token authentication
Fix: add a `ClientInterface#set_bearer_token` authentication method, which uses HTTP BASIC auth with a bearer token instead of a base64 encoded username/password