### PR TITLE
Updated code in get_oauth2_metadata_from_conformance to be the correc…

### DIFF
--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -128,7 +128,7 @@ module FHIR
       conformance.rest.each do |rest|
         rest.security.service.each do |service|
           service.coding.each do |coding|
-            if coding.code == 'OAuth2'
+            if coding.code == 'SMART-on-FHIR'
               rest.security.extension.where({url: oauth_extension}).first.extension.each do |ext|
                 case ext.url
                 when authorize_extension


### PR DESCRIPTION
…t one from the valueset for Smart on FHIR