### PR TITLE
Fixes an issue with http method selection for search. 

### DIFF
--- a/lib/sections/search.rb
+++ b/lib/sections/search.rb
@@ -12,8 +12,7 @@ module FHIR
       def search(klass, options={}, format=@default_format_bundle)
         options.merge!({ resource: klass, format: format })
 
-#        if options[:search][:flag]
-        if options.has_key? :search  and options.has_key? :flag
+        if options[:search] && options[:search][:flag]
           reply = post resource_url(options), nil, fhir_headers(options)
         else
           reply = get resource_url(options), fhir_headers(options)
@@ -27,7 +26,7 @@ module FHIR
       def search_existing(klass, id, options={}, format=@default_format_bundle)
         options.merge!({ resource: klass, id: id, format: format })
         #if options[:search][:flag]
-        if options.has_key? :search  and options.has_key? :flag
+        if options[:search] && options[:search][:flag]
           reply = post resource_url(options), nil, fhir_headers(options)
         else
           reply = get resource_url(options), fhir_headers(options)
@@ -39,7 +38,7 @@ module FHIR
 
       def search_all(options={}, format=@default_format_bundle)
         options.merge!({ format: format })
-        if options[:search][:flag]
+        if options[:search] && options[:search][:flag]
           reply = post resource_url(options), nil, fhir_headers(options)
         else
           reply = get resource_url(options), fhir_headers(options)


### PR DESCRIPTION
The :flag parameter under search options was not being checked properly.  The first issue was that it was checking for key presence rather than a value of true/false.  The second issue was that it was checking for :flag at the root of options rather than under :search