### PR TITLE
move dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,6 @@
 source "http://rubygems.org"
 gemspec
 
-gem 'rake'
-gem 'pry'
-gem 'tilt'
-gem 'rails', '>= 4.0.0'
-gem 'nokogiri'
-gem 'fhir_models', :git => 'https://github.com/fhir-crucible/fhir_models', :branch => 'master'
-gem 'rest-client'
-gem 'date_time_precision'
-gem 'bcp47'
-gem 'addressable'
-gem 'oauth2'
-
 group :test do
   gem 'simplecov', :require => false
   gem 'minitest', "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,101 +1,68 @@
-GIT
-  remote: https://github.com/fhir-crucible/fhir_models
-  revision: 8ff80be80b73777892680d9a618ce50ba330b9b4
-  branch: master
-  specs:
-    fhir_models (1.0.0)
-
 PATH
   remote: .
   specs:
     fhir_client (1.0.0)
+      activesupport (>= 3)
+      addressable (>= 2.3)
+      fhir_models (~> 0.3)
+      oauth2 (~> 1.1)
+      rest-client (~> 1.8)
+      tilt (~> 2.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    actionmailer (4.0.13)
-      actionpack (= 4.0.13)
-      mail (~> 2.5, >= 2.5.4)
-    actionpack (4.0.13)
-      activesupport (= 4.0.13)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
-      rack (~> 1.5.2)
-      rack-test (~> 0.6.2)
-    activemodel (4.0.13)
-      activesupport (= 4.0.13)
-      builder (~> 3.1.0)
-    activerecord (4.0.13)
-      activemodel (= 4.0.13)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.13)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.4)
     activesupport (4.0.13)
       i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.3.8)
+    addressable (2.4.0)
     ansi (1.5.0)
-    arel (4.0.2)
     awesome_print (1.6.1)
     bcp47 (0.3.3)
       i18n
-    builder (3.1.4)
-    coderay (1.1.0)
-    date_time_precision (0.8.0)
+    coderay (1.1.1)
+    date_time_precision (0.8.1)
     docile (1.1.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
-    erubis (2.7.0)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    fhir_models (0.3.0)
+      bcp47 (>= 0.3)
+      date_time_precision (>= 0.8)
+      mime-types (>= 1.16, < 3)
+      nokogiri (>= 1.6)
+      rake (>= 0.8.7)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.2)
     jwt (1.5.1)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.4.3)
-    mini_portile (0.6.2)
+    mime-types (2.99.1)
+    mini_portile2 (2.0.0)
     minitest (4.7.5)
-    multi_json (1.11.0)
+    multi_json (1.12.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    oauth2 (1.0.0)
+    netrc (0.11.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    oauth2 (1.1.0)
       faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+      jwt (~> 1.0, < 1.5.2)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    pry (0.10.1)
+      rack (>= 1.2, < 3)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.5.2)
-    rack-test (0.6.3)
-      rack (>= 1.0)
-    rails (4.0.13)
-      actionmailer (= 4.0.13)
-      actionpack (= 4.0.13)
-      activerecord (= 4.0.13)
-      activesupport (= 4.0.13)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.13)
-      sprockets-rails (~> 2.0)
-    railties (4.0.13)
-      actionpack (= 4.0.13)
-      activesupport (= 4.0.13)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rack (1.6.4)
+    rake (11.1.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -106,42 +73,25 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    sprockets (3.0.2)
-      rack (~> 1.0)
-    sprockets-rails (2.2.4)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
-    thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (2.0.2)
     turn (0.9.7)
       ansi
       minitest (~> 4)
-    tzinfo (0.3.43)
+    tzinfo (0.3.49)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable
   awesome_print
-  bcp47
-  date_time_precision
   fhir_client!
-  fhir_models!
   minitest (~> 4.0)
-  nokogiri
-  oauth2
   pry
-  rails (>= 4.0.0)
-  rake
-  rest-client
   simplecov
-  tilt
   turn
 
 BUNDLED WITH

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -10,6 +10,14 @@ Gem::Specification.new do |s|
   s.version = '1.0.0'
 
   s.files = s.files = `git ls-files`.split("\n")
+
+  s.add_dependency 'fhir_models', '~> 0.3'
+  s.add_dependency 'tilt', '~> 2.0'
+  s.add_dependency 'rest-client', '~> 1.8'
+  s.add_dependency 'oauth2', '~> 1.1'
+  s.add_dependency 'activesupport', '>= 3'
+  s.add_dependency 'addressable', '>= 2.3'
+  s.add_development_dependency 'pry'
 end
 
 

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -7,6 +7,7 @@ require 'fhir_models'
 require 'rest_client'
 require 'addressable/uri'
 require 'oauth2'
+require 'active_support/core_ext'
 
 # Simple and verbose loggers
 RestClient.log = Logger.new("fhir_client.log", 10, 1024000)


### PR DESCRIPTION
This prepares `fhir_client` to become a gem, as well.

Note: I did remove the dependency on `rails >= 4` in favor of a weaker (`>= 3`) dependency on `activesupport`. It seems like `rails` isn't really required for this library, and I think the only thing from `activesupport` is being used for is some `deep_merge` and `try` statements, so I'm only requiring `active_support/core_ext`.

Subnote: I set the dependency for `fhir_models` to be `~> 0.3`, but maybe it should be looser? Although it's still possible to point to a different version of `fhir_models` in libraries including `fhir_client` by just specifying `gem 'fhir_models', git: '...'` in the gemfile.

But the bright side is, now in our main app, we can just do:
![image](https://cloud.githubusercontent.com/assets/1022564/15153813/b386888c-16a8-11e6-80d4-998971009009.png)
to include everything without restating any subdependencies.
 