### PR TITLE
first pass at simple association between client and models

### DIFF
--- a/lib/fhir_model.rb
+++ b/lib/fhir_model.rb
@@ -1,0 +1,46 @@
+module FHIR
+  class Model
+    attr_reader :client
+
+    def client=(client)
+      @client = client
+
+      # Ensure the client-setting cascades to all child models
+      instance_values.each do |key, values|
+        Array.wrap(values).each do |value|
+          next unless value.is_a?(FHIR::Model)
+          next if value.client == client
+          value.client = client
+        end
+      end
+    end
+
+    def self.resource_for(reply)
+      reply.resource || raise("Request #{reply.request} failed with #{reply.response}")
+    end
+
+    def self.read(client, id)
+      model = resource_for(client.read(self, id))
+      model.tap { |m| m.client = client }
+    end
+
+    def self.search(client, params)
+      # TODO: if there are multiple pages, either fetch them all or return an
+      # enumerator that can lazily fetch the rest
+      bundle = resource_for(client.search(self, search: { parameters: params }))
+      models = bundle.entry.map(&:resource)
+      models.each { |m| m.client = client }
+    end
+  end
+
+  class Reference
+    def read
+      raise "Missing client, unable to follow reference" unless client
+      # TODO: how to follow contained references?
+      type, id = reference.to_s.split("/")
+      return unless [type, id].all?(&:present?)
+      klass = "FHIR::#{type}".constantize
+      klass.read(client, id)
+    end
+  end
+end


### PR DESCRIPTION
This is just for consideration, and probably needs a bit more testing, but we've been using this on our application and it's worked pretty well.

Usage like this:

```ruby
client = FHIR::Client.new(url)

# get a model object rather than a response
patient = FHIR::Patient.read(client, patient_id)

# follow one of its `FHIR::Reference`s
provider = patient.careProvider.first.read

# do a search and get an array of model objects instead of a bundle response
observations = FHIR::Observation.search(client, patient: patient.id)
```

It's not fully-featured, but I think the spoonful of extra syntactic sugar helps a lot of medicine go down (and  get communicated 😄). We probably need to ensure we handle Bundle paging properly before merging this, though.