### PR TITLE
API redesign updates

### DIFF
--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -214,6 +214,7 @@ module FHIR
       $LOG.error "Failed to parse #{format} as resource #{klass}: #{e.message} %n #{e.backtrace.join("\n")} #{response}"
       nil
     end
+    res.client = self
     res
   end
 

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -38,7 +38,7 @@ module FHIR
     def next_bundle
       # TODO: test this
       return nil unless client && next_link.try(:url)
-      client.parse_reply(client.raw_read_url(next_link.url))
+      @next_bundle ||= client.parse_reply(client.raw_read_url(next_link.url))
     end
   end
 end

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -30,21 +30,16 @@ module FHIR
     end
 
     def each(&block)
-      @entry.each(&block)
+      iteration = @entry.map(&:resource).each(&block)
+      iteration += next_bundle.each(&block) if next_bundle
+      iteration
     end
 
-    # TODO: upgrade client to easily get a bundle if given a link
-    # def next
-    #   return nil if next_link.nil?
-    #   self.class.last_response = self.class.configuration.client.raw_read_url next_link.url
-    #   self.class.last_response.resource
-    # end
-
-    # def previous
-    #   return nil if previous_link.nil?
-    #   self.class.last_response = self.class.configuration.client.raw_read_url previous_link.url
-    #   self.class.last_response.resource
-    # end
+    def next_bundle
+      # TODO: test this
+      return nil unless client && next_link.try(:url)
+      client.parse_reply(client.raw_read_url(next_link.url))
+    end
   end
 end
 

--- a/lib/ext/model.rb
+++ b/lib/ext/model.rb
@@ -18,6 +18,10 @@ module FHIR
     def self.read(client, id)
       client.read(self, id).resource
     end
+
+    def self.search(client, params = {})
+      client.search(self, search: { parameters: params }).resource
+    end
   end
 end
 

--- a/lib/ext/model.rb
+++ b/lib/ext/model.rb
@@ -22,86 +22,18 @@ module FHIR
     def self.search(client, params = {})
       client.search(self, search: { parameters: params }).resource
     end
-  end
-end
 
-__END__
-    attr_accessor :client
-
-    class << self
-      cattr_accessor :configuration
+    def self.create(client, model)
+      model = self.new(model) unless model.is_a?(self)
+      client.create(model).resource
     end
 
-    def self.configure
-      self.configuration ||= Configuration.new
-      yield configuration
+    def update
+      client.update(self, id).resource
     end
 
-    # class methods 
-
-    def self.find(id, options = {})
-      client = self.pull_client_from options
-      response = client.read(self, id, client.default_format, options[:summary], options)
-      response.resource.client = client unless response.resource.nil?
-      response.resource
+    def destroy
+      client.destroy(self, id)
     end
-
-    def self.all(options = {})
-      client = pull_client_from options
-      response = client.read_feed(self)
-      response.resource.client = client unless response.resource.nil?
-      response.resource
-    end
-
-    def self.create(options)
-      client = pull_client_from options
-      resource = self.new.from_hash(options)
-      response = client.create(resource)
-      response.resource.client = client unless response.resource.nil?
-      response.resource
-    end
-
-    def self.destroy(id, options = {})
-      client = pull_client_from options
-      response = client.destroy(self, id)
-      nil
-    end
-
-    def self.where(options)
-      client = pull_client_from options
-
-      options = { search: { parameters: options }}
-      response = client.search(self, options)
-      response.resource.client = client unless response.resource.nil?
-      response.resource
-    end
-
-    # instance methods
-
-    def save(options = {})
-      client = self.class.pull_client_from options, @client
-      if self.id.nil?
-        last_response = client.create(self)
-      else
-        last_response = client.update(self, self.id)
-      end
-      last_response.resource
-    end
-
-    def destroy(options = {})
-      client = self.class.pull_client_from options, @client
-      self.class.destroy(self.id, client: client) unless self.id.nil?
-    end
-
-    private
-
-    def self.pull_client_from(options, instance_client = nil)
-      options.delete(:client) || instance_client || self.configuration.client
-    end
-
-    class Configuration
-      attr_accessor :client
-    end
-
   end
 end

--- a/lib/ext/model.rb
+++ b/lib/ext/model.rb
@@ -1,6 +1,27 @@
 module FHIR
   class Model
+    attr_reader :client
 
+    def client=(client)
+      @client = client
+
+      # Ensure the client-setting cascades to all child models
+      instance_values.each do |_key, values|
+        Array.wrap(values).each do |value|
+          next unless value.is_a?(FHIR::Model)
+          next if value.client == client
+          value.client = client
+        end
+      end
+    end
+
+    def self.read(client, id)
+      client.read(self, id).resource
+    end
+  end
+end
+
+__END__
     attr_accessor :client
 
     class << self

--- a/lib/ext/reference.rb
+++ b/lib/ext/reference.rb
@@ -1,0 +1,11 @@
+module FHIR
+  class Reference
+    def read
+      # TODO: how to follow contained references?
+      type, id = reference.to_s.split("/")
+      return unless [type, id].all?(&:present?)
+      klass = "FHIR::#{type}".constantize
+      klass.read(client, id)
+    end
+  end
+end

--- a/lib/sections/crud.rb
+++ b/lib/sections/crud.rb
@@ -163,6 +163,7 @@ module FHIR
           resource.id = FHIR::ResourceAddress.pull_out_id(resource.class.name.demodulize, reply.response[:headers]['location'])
           reply.resource = resource # just send back the submitted resource
         end
+        reply.resource.client = self
         reply.resource_class = resource.class
         reply
       end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -13,27 +13,29 @@ namespace :fhir do
 
     FHIR::Model.configure { |c| c.client = client }
 
-    patient1 = FHIR::Patient.create(name: {given: 'Joe', family: 'Smith'})
-    patient2 = FHIR::Patient.create(name: {given: 'Joe', family: 'Smith'}, client: client2)
+    patient1 = FHIR::Patient.create(client, name: {given: 'Joe', family: 'Smith'})
+    patient2 = FHIR::Patient.create(client2, name: {given: 'Joe', family: 'Smith'})
 
-    results = FHIR::Patient.where(given: 'Joe', family: 'Smith')
-    results = FHIR::Patient.where(given: 'Joe', family: 'Smith', client: client2)
+    results = FHIR::Patient.search(client, given: 'Joe', family: 'Smith')
+    results = FHIR::Patient.search(client2, given: 'Joe', family: 'Smith')
 
-    patient1.save
+    patient1.update
     patient2.name[0].family = 'Smithfield'
-    patient2.save
+    patient2.update
 
-    patient_check = FHIR::Patient.find(patient1.id)
-    patient_check = FHIR::Patient.find(patient1.id, client: client)
+    patient_check = FHIR::Patient.read(client2, patient1.id)
+    patient_check = FHIR::Patient.read(client, patient1.id)
 
     patient3 = FHIR::Patient.new(name: {given: 'Sam', family: 'Jones'})
-    patient3.save(client:client)
+    patient3.client = client
+    patient3.update
     patient4 = FHIR::Patient.new(name: {given: 'Sam', family: 'Jones'})
-    patient4.save(client: client2)
-    patient_check = FHIR::Patient.find(patient1.id)
+    patient4.client = client
+    patient4.update
+    patient_check = FHIR::Patient.read(client, patient1.id)
 
-    all_patients = FHIR::Patient.all()
-    all_patients = FHIR::Patient.all(client: client2)
+    #all_patients = FHIR::Patient.all()
+    #all_patients = FHIR::Patient.all(client: client2)
 
     # all_patients.count() # enumerable
 
@@ -47,7 +49,7 @@ namespace :fhir do
   task :api_testing_noconfig, [] do |t, args|
 
     client = FHIR::Client.new 'http://fhirtest.uhn.ca/baseDstu3'
-    patient = FHIR::Patient.create(name: {given: 'Joe', family: 'Smith'}, client: client)
+    patient = FHIR::Patient.create(client, name: {given: 'Joe', family: 'Smith'})
     patient.destroy
 
   end


### PR DESCRIPTION
Per https://github.com/fhir-crucible/fhir_client/pull/23. 

Also see this [wiki entry](https://github.com/fhir-crucible/fhir_client/wiki/Following-references-(remote-and-contained)), which has some thoughts about alternatives to the code included here to support `FHIR::Reference#read`.