### PR TITLE
Throw exceptions for 4xx & 5xx http codes

### DIFF
--- a/lib/client_exception.rb
+++ b/lib/client_exception.rb
@@ -1,0 +1,10 @@
+class ClientException < Exception
+
+  attr_accessor :reply
+
+  def initialize(message, reply = nil)
+    super(message)
+    @reply = reply
+  end
+
+end

--- a/lib/ext/model.rb
+++ b/lib/ext/model.rb
@@ -22,46 +22,57 @@ module FHIR
     end
 
     def self.read(id, client = self.client)
-      client.read(self, id).resource
+      handle_response client.read(self, id)
     end
 
     def self.read_with_summary(id, summary, client = self.client)
-      client.read(self, id, client.default_format, summary).resource
+      handle_response client.read(self, id, client.default_format, summary)
     end
 
     def self.search(params = {}, client = self.client)
-      client.search(self, search: { parameters: params }).resource
+      handle_response client.search(self, search: { parameters: params })
     end
 
     def self.create(model, client = self.client)
       model = new(model) unless model.is_a?(self)
-      client.create(model).resource
+      handle_response client.create(model)
     end
 
     def self.conditional_create(model, params, client = self.client)
       model = new(model) unless model.is_a?(self)
-      client.conditional_create(model, params)
+      handle_response client.conditional_create(model, params)
     end
 
     def create
-      client.create(self).resource
+      handle_response client.create(self).resource
     end
 
     def conditional_create(params)
-      client.conditional_create(self, params)
+      handle_response client.conditional_create(self, params)
     end
 
     def update
-      client.update(self, id).resource
+      handle_response client.update(self, id)
     end
 
     def conditional_update(params)
-      client.conditional_update(self, self.id, params).resource
+      handle_response client.conditional_update(self, self.id, params)
     end
 
     def destroy
-      client.destroy(self.class, id) unless id.nil?
+      handle_response client.destroy(self.class, id) unless id.nil?
       nil
+    end
+
+    private
+
+    def self.handle_response(response)
+      raise ClientException.new "Server returned #{response.code}.", response if response.code.between?(400,599)
+      response.resource
+    end
+
+    def handle_response(response)
+      self.class.handle_response(response)
     end
   end
 end

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -28,4 +28,4 @@ require_relative File.join('.','feed_format.rb')
 require_relative File.join('.','patch_format.rb')
 require_relative File.join('.','model','client_reply.rb')
 require_relative File.join('.','model','tag.rb')
-
+require_relative File.join('.','client_exception.rb')


### PR DESCRIPTION
Added exceptions to the new API if the server returns a 4xx or 5xx http code.  Perhaps this is better suited within the client itself, and not the extensions that we are adding to the models, but that would break all of our old tests in Crucible.