### PR TITLE
add helper to resolve contained references (and fix bug)

### DIFF
--- a/lib/ext/model.rb
+++ b/lib/ext/model.rb
@@ -64,6 +64,14 @@ module FHIR
       nil
     end
 
+    def resolve(reference)
+      if reference.contained?
+        contained.detect { |c| c.id == reference.id }
+      else
+        reference.read
+      end
+    end
+
     private
 
     def self.handle_response(response)

--- a/lib/ext/reference.rb
+++ b/lib/ext/reference.rb
@@ -1,11 +1,28 @@
 module FHIR
   class Reference
+    def contained?
+      reference.to_s.start_with?('#')
+    end
+
+    def id
+      if contained?
+        reference.to_s[1..-1]
+      else
+        reference.to_s.split('/').last
+      end
+    end
+
+    def type
+      reference.to_s.split('/').first unless contained?
+    end
+
+    def resource_class
+      "FHIR::#{type}".constantize unless contained?
+    end
+
     def read
-      # TODO: how to follow contained references?
-      type, id = reference.to_s.split("/")
-      return unless [type, id].all?(&:present?)
-      klass = "FHIR::#{type}".constantize
-      klass.read(client, id)
+      return if contained? || type.blank? || id.blank?
+      resource_class.read(id, client)
     end
   end
 end


### PR DESCRIPTION
This just fixes the current implementation of `FHIR::Reference#read` (which had the wrong argument order) and adds a helper to `FHIR::Model` to `resolve` both contained and external references.

I still plan to take a crack at some `fhir_models` changes which would make this more elegant, but things have been very busy!

Thanks again for merging the previous changes.