### PR TITLE
replace $LOG with configurable FHIR::Client.logger

### DIFF
--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -9,10 +9,6 @@ require 'addressable/uri'
 require 'oauth2'
 require 'active_support/core_ext'
 
-# Simple and verbose loggers
-RestClient.log = Logger.new("fhir_client.log", 10, 1024000)
-$LOG = Logger.new("fhir_client_verbose.log", 10, 1024000)
-
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 Dir.glob(File.join(root, 'lib','sections','**','*.rb')).each do |file|
   require file


### PR DESCRIPTION
This allows us to do:
```ruby
# config/initializers/fhir_client.rb
FHIR::Client.logger = Rails.logger
```
which lets us take advantage of our existing log encryption/rotation strategies for our deployments. It also prevents `fhir_client` from generating log files in our app's root directory :)

Note it also removes `RestClient.log = Logger.new("fhir_client.log", 10, 1024000)`, so if you wanted to keep that behavior in your other libraries that use this, you'd need to re-add that line in an initializer. The reasoning behind that is that other libraries might use `RestClient` for non-FHIR purposes, so we shouldn't assume that we can safely set its sole logger to `fhir_client.log`.