### PR TITLE
Fix reissue request bug introduced in stu3.

### DIFF
--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -226,13 +226,7 @@ module FHIR
     if [:get, :delete, :head].include?(request['method'])
       method(request['method']).call(request['url'], request['headers'])
     elsif [:post, :put].include?(request['method'])
-      if request['payload'] != nil
-        if request['headers']['format'].downcase.include?('xml')
-          resource = FHIR::Xml.from_xml(request['payload'])
-        else
-          resource = FHIR::Json.from_json(request['payload'])
-        end
-      end
+      resource = FHIR.from_contents(request['payload']) unless request['payload'].nil?
       method(request['method']).call(request['url'], resource, request['headers'])
     end
   end

--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -226,7 +226,13 @@ module FHIR
     if [:get, :delete, :head].include?(request['method'])
       method(request['method']).call(request['url'], request['headers'])
     elsif [:post, :put].include?(request['method'])
-      resource = request['headers']['resource'].constantize.from_xml(request['payload'])
+      if request['payload'] != nil
+        if request['headers']['format'].downcase.include?('xml')
+          resource = FHIR::Xml.from_xml(request['payload'])
+        else
+          resource = FHIR::Json.from_json(request['payload'])
+        end
+      end
       method(request['method']).call(request['url'], resource, request['headers'])
     end
   end


### PR DESCRIPTION
If you try to reissue a request for a POST, PUT, or DELETE, it will return a 500 on crucible because it uses the old from_xml method from dstu2.  A good place to try is on the Patient Resource test on crucible.  Before this the create and update tests will not be able to have their requests reissued.  After this fix it will work.