### PR TITLE
Fix flipped arguments to `FHIR::Klass.read`

### DIFF
--- a/lib/ext/reference.rb
+++ b/lib/ext/reference.rb
@@ -5,7 +5,7 @@ module FHIR
       type, id = reference.to_s.split("/")
       return unless [type, id].all?(&:present?)
       klass = "FHIR::#{type}".constantize
-      klass.read(client, id)
+      klass.read(id, client)
     end
   end
 end


### PR DESCRIPTION
When getting a reference, the call to `FHIR::Klass.read` (where `Klass` is some
FHIR model) had its arguments flipped: the `id` should come first, and the
`client` second.