### PR TITLE
Soften version requirement for `rack`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       addressable (>= 2.3)
       fhir_models (>= 1.6.1)
       oauth2 (~> 1.1)
-      rack (~> 1.5)
+      rack (>= 1.5)
       rest-client (~> 1.8)
       tilt (>= 1.1)
 
@@ -64,7 +64,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.4)
+    rack (2.0.1)
     rake (11.2.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '~> 1.1'
   s.add_dependency 'activesupport', '>= 3'
   s.add_dependency 'addressable', '>= 2.3'
-  s.add_dependency 'rack', '~> 1.5'
+  s.add_dependency 'rack', '>= 1.5'
   s.add_development_dependency 'pry'
 end
 


### PR DESCRIPTION
Rails 5 has a hard dependency on Rack ~> 2.0, which FHIR::Client conflicted with, itself having a hard dependency on ~> 1.5 (or ~> 1.6, I guess).

I saw that the version of Rack was a topic of committing recently — if this is unfeasible at the moment, I'd be happy to help get to a Rack 2.0 future.