### PR TITLE
Fix rack dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - "2.1.10"
   - "2.2.5"
   - "2.3.1"
+before_install:
+  - gem install bundler
 services: mongodb
 script: bundle exec rake test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - "2.0.0"
+  - "2.1.10"
+  - "2.2.5"
+  - "2.3.1"
 services: mongodb
 script: bundle exec rake test
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
-source "http://rubygems.org"
+source 'http://rubygems.org'
+ruby RUBY_VERSION
 gemspec
 
 group :test do
-  gem 'simplecov', :require => false
-  gem 'minitest', "~> 4.0"
-  gem 'turn', :require => false
-  gem 'awesome_print', :require => 'ap'
+  gem 'simplecov', require: false
+  gem 'minitest', '~> 4.0'
+  gem 'turn', require: false
+  gem 'awesome_print', require: 'ap'
 end

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '~> 1.1'
   s.add_dependency 'activesupport', '>= 3'
   s.add_dependency 'addressable', '>= 2.3'
-  s.add_dependency 'rack', '~> 1.5'
+  s.add_dependency 'rack', '>= 1.5'
   s.add_dependency 'nokogiri'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
This allows bundler to be smart about what version of rack it pulls in.  Rack 2.0 is only compatible with ruby >= 2.2.2 and the previous gem specification interfered with installing newer versions when necessary.

I've also added some travis configs so that it explicitly builds against ruby `2.1.10`, `2.2.5`, and `2.3.1`