### PR TITLE
cattr_accessor doesn't need self-inheriting subclass

### DIFF
--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -1,8 +1,6 @@
 module FHIR
   class Model
-    class << self
-      cattr_accessor :client, instance_accessor: false
-    end
+    cattr_accessor :client, instance_accessor: false
 
     def client
       @@client


### PR DESCRIPTION
With `:instance_accessor => false`, you don't need to wrap
`cattr_accessor` in `class << self` to keep it from percolating down to
the instances, and doing so means that it doesn't even get attached as
methods to the class itself.