### PR TITLE
Patch OAuth2 to support FHIR mime-types

### DIFF
--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -9,6 +9,7 @@ Dir.glob(File.join(root, 'fhir_client', 'ext', '**', '*.rb')).each do |file|
   require file
 end
 
+require_relative 'fhir_client/gem_ext'
 require_relative 'fhir_client/client'
 require_relative 'fhir_client/resource_address'
 require_relative 'fhir_client/resource_format'

--- a/lib/fhir_client/gem_ext.rb
+++ b/lib/fhir_client/gem_ext.rb
@@ -1,0 +1,1 @@
+require_relative 'gem_ext/oauth2'

--- a/lib/fhir_client/gem_ext/oauth2.rb
+++ b/lib/fhir_client/gem_ext/oauth2.rb
@@ -1,0 +1,1 @@
+require_relative 'oauth2/response'

--- a/lib/fhir_client/gem_ext/oauth2/response.rb
+++ b/lib/fhir_client/gem_ext/oauth2/response.rb
@@ -1,0 +1,18 @@
+require 'oauth2/response'
+
+module OAuth2
+  class Response
+    @@content_types = {
+      'application/json' => :json,
+      'application/fhir+json' => :json,
+      'text/javascript' => :json,
+      'application/x-www-form-urlencoded' => :query,
+      'text/plain' => :text
+    }
+  end
+end
+
+# Add application/fhir+xml
+OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml', 'application/fhir+xml']) do |body|
+  MultiXml.parse(body) rescue body
+end


### PR DESCRIPTION
Since 1.8, the specification states `application/xml+fhir` and `application/json+fhir` mime types.