### PR TITLE
Remove trailing slash in history in stu3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - "2.2.5"
   - "2.3.1"
 before_install:
+  - gem update --system
   - gem install bundler
 services: mongodb
 script:

--- a/lib/fhir_client/resource_address.rb
+++ b/lib/fhir_client/resource_address.rb
@@ -76,7 +76,7 @@ module FHIR
 
       if options[:history]
         history = options[:history]
-        url += "/_history"
+        url += '/_history'
         url += "/#{history[:id]}" if history.key?(:id)
         params[:_count] = history[:count] if history[:count]
         params[:_since] = history[:since].iso8601 if history[:since]

--- a/lib/fhir_client/resource_address.rb
+++ b/lib/fhir_client/resource_address.rb
@@ -76,7 +76,8 @@ module FHIR
 
       if options[:history]
         history = options[:history]
-        url += "/_history/#{history[:id]}"
+        url += "/_history"
+        url += "/#{history[:id]}" if history.key?(:id)
         params[:_count] = history[:count] if history[:count]
         params[:_since] = history[:since].iso8601 if history[:since]
       end


### PR DESCRIPTION
Removes trailing slash from _history. I did some research and it appears that both are valid from a general RESTFUL perspective (having _history/ vs just _history)... but all the examples on the FHIR site omit the slash, and we omit the slash in other cases. So I think we should just stay consistent.

This is to fix the stu3 branch (master).