### PR TITLE
Update/Conditional Update parse reply

### DIFF
--- a/lib/fhir_client/sections/crud.rb
+++ b/lib/fhir_client/sections/crud.rb
@@ -78,7 +78,7 @@ module FHIR
         options[:format] = format
         options[:id] = id
         reply = put resource_url(options), resource, fhir_headers(options)
-        reply.resource = parse_reply(resource.class, format, reply)
+        reply.resource = parse_reply(resource.class, format, reply) if reply.body.present?
         reply.resource_class = resource.class
         reply
       end


### PR DESCRIPTION
The resource is not required in the response of an update or conditional update. Fhir client expects the resource to be in the body of the response and does validations on the response body. We only need to `parse_reply` if the resource is returned in the response body. 