### PR TITLE
Added missing CRUD method and downgraded rest-client dependency

### DIFF
--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'oauth2', '~> 1.1'
   spec.add_dependency 'rack', '>= 1.5'
-  spec.add_dependency 'rest-client', '~> 2.0'
+  spec.add_dependency 'rest-client', '~> 1.8'
   spec.add_dependency 'tilt', '>= 1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.13'

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -61,6 +61,10 @@ module FHIR
       handle_response client.conditional_create(model, params)
     end
 
+    def self.partial_update(id, patchset, options = {})
+      handle_response client.partial_update(self, id, patchset, options = {})
+    end
+
     def self.all(client = @@client)
       handle_response client.read_feed(self)
     end


### PR DESCRIPTION
This PR is linked to #70 as we noticed that the `partial_update` method was missing on the model concern (we had to use it on the client and thus bypassing the error response handling).

This fork was designed to be used on our system which uses `refile` and have a string dependency on `rest-client` 1.8.