### PR TITLE
Implement & test Bundle#next_bundle

### DIFF
--- a/lib/fhir_client/sections/crud.rb
+++ b/lib/fhir_client/sections/crud.rb
@@ -36,13 +36,11 @@ module FHIR
       end
 
       def raw_read(options)
-        reply = get resource_url(options), fhir_headers(options)
-        reply.body
+        get resource_url(options), fhir_headers(options)
       end
 
-      def raw_read_url(url)
-        reply = get url, fhir_headers({})
-        reply.body
+      def raw_read_url(url, format = @default_format)
+        get url, fhir_headers(format: format)
       end
 
       #

--- a/test/fixtures/next-bundle-example.xml
+++ b/test/fixtures/next-bundle-example.xml
@@ -1,0 +1,77 @@
+<Bundle xmlns="http://hl7.org/fhir">
+  <id value="next-example"/>
+  <meta>
+    <versionId value="1"/>
+    <lastUpdated value="2014-08-18T01:43:30Z"/>
+  </meta>
+  <type value="transaction"/>
+  <base value="http://example.com/base"/>
+  <total value="2"/>
+  <link>
+    <relation value="self"/>
+    <url value="https://example.com/base/MedicationRequest?patient=347&amp;searchId=ff15fd40-ff71-4b48-b366-09c
+      706bed9d0&amp;page=2"/>
+  </link>
+  <entry>
+    <status value="update"/>
+    <resource>
+      <MedicationRequest>
+        <id value="3124"/>
+        <meta>
+          <versionId value="1"/>
+          <lastUpdated value="2014-08-16T05:31:17Z"/>
+        </meta>
+        <text>
+          <status value="generated"/>
+          <div xmlns="http://www.w3.org/1999/xhtml">
+            <!-- Snipped for brevity -->
+          </div>
+        </text>
+        <status value="active"/>
+        <patient>
+          <reference value="Patient/example"/>
+        </patient>
+        <prescriber>
+          <reference value="Practitioner/example"/>
+        </prescriber>
+
+        <medicationReference>
+          <reference value="Medication/example"/>
+        </medicationReference>
+
+        <dosageInstruction>
+          <timing>
+            <repeat>
+              <frequency value="3"/>
+              <duration value="1"/>
+              <units value="d"/>
+            </repeat>
+          </timing>
+          <route>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="394899003"/>
+              <display value="oral administration of treatment"/>
+            </coding>
+          </route>
+          <doseQuantity>
+            <value value="5"/>
+            <units value="ml"/>
+            <system value="http://unitsofmeasure.org"/>
+            <code value="ml"/>
+          </doseQuantity>
+        </dosageInstruction>
+
+        <dispenseRequest>
+          <quantity>
+            <value value="100"/>
+            <units value="ml"/>
+            <system value="http://unitsofmeasure.org"/>
+            <code value="ml"/>
+          </quantity>
+        </dispenseRequest>
+
+      </MedicationRequest>
+    </resource>
+  </entry>
+</Bundle>

--- a/test/unit/bundle_test.rb
+++ b/test/unit/bundle_test.rb
@@ -16,4 +16,66 @@ class BundleTest < Test::Unit::TestCase
 
     assert !bundle.nil?, 'Failed to parse example Bundle.'
   end
+
+  def test_next_bundle
+    client = FHIR::Client.new('feed-test')
+    root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+    bundle_xml = File.read(File.join(root, 'fixtures', 'bundle-example.xml'))
+    response = {
+      code: '200',
+      headers: {},
+      body: bundle_xml
+    }
+    clientReply = FHIR::ClientReply.new('feed-test', response)
+
+    bundle = client.parse_reply(FHIR::Bundle, FHIR::Formats::ResourceFormat::RESOURCE_XML, clientReply)
+    next_bundle_xml = File.read(File.join(root, 'fixtures', 'next-bundle-example.xml'))
+    WebMock.stub_request(:any, bundle.next_link.url).to_return status: 200, body: next_bundle_xml
+    next_bundle = bundle.next_bundle
+
+    assert !next_bundle.nil?, 'Failed to retrieve next Bundle.'
+  end
+
+  def test_each
+    client = FHIR::Client.new('feed-test')
+    root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+    bundle_xml = File.read(File.join(root, 'fixtures', 'bundle-example.xml'))
+    response = {
+      code: '200',
+      headers: {},
+      body: bundle_xml
+    }
+    clientReply = FHIR::ClientReply.new('feed-test', response)
+
+    bundle = client.parse_reply(FHIR::Bundle, FHIR::Formats::ResourceFormat::RESOURCE_XML, clientReply)
+    next_bundle_xml = File.read(File.join(root, 'fixtures', 'next-bundle-example.xml'))
+    WebMock.stub_request(:any, bundle.next_link.url).to_return status: 200, body: next_bundle_xml
+
+    counter = 0
+    bundle.each do |entry|
+      counter += 1
+    end
+
+    assert counter == 2, "Called block #{counter} times. Expected 2"
+  end
+
+  def test_each_no_block
+    client = FHIR::Client.new('feed-test')
+    root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+    bundle_xml = File.read(File.join(root, 'fixtures', 'bundle-example.xml'))
+    response = {
+      code: '200',
+      headers: {},
+      body: bundle_xml
+    }
+    clientReply = FHIR::ClientReply.new('feed-test', response)
+
+    bundle = client.parse_reply(FHIR::Bundle, FHIR::Formats::ResourceFormat::RESOURCE_XML, clientReply)
+    next_bundle_xml = File.read(File.join(root, 'fixtures', 'next-bundle-example.xml'))
+    WebMock.stub_request(:any, bundle.next_link.url).to_return status: 200, body: next_bundle_xml
+
+    iterator = bundle.each
+
+    assert iterator.count == 2, "Iterator should have had 2 elements."
+  end
 end


### PR DESCRIPTION
Fixed some issues around `next_bundle`

1. `Client#parse_reply` was expecting a response as the third argument, but it was getting `response.body`
1. `Bundle#each` was throwing an error when called when a next bundle exists, but without a block.
1. It was previously impossible to call `raw_read_url` with any format other than `application/fhir+xml`