### PR TITLE
Allow to handle base_create method directly from models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ patient = FHIR::Patient.read('example')
 
 # update a patient
 patient.gender = 'female'
-patient.update # saves the patient 
+patient.update # saves the patient
 
 # create a patient
 patient = FHIR::Patient.create(name: {given: 'John', family: 'Doe'})
@@ -66,6 +66,11 @@ patient = client.read(FHIR::Patient, "example", FHIR::Formats::FeedFormat::FEED_
 # create a patient
 patient = FHIR::Patient.new
 patient_id = client.create(patient).id
+
+# create a patient with specific headers
+patient = FHIR::Patient.new
+options = { :Prefer => "return=representation" }
+patient_id = patient.base_create(options)
 
 # update the patient
 patient.gender = 'female'

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -77,6 +77,10 @@ module FHIR
       handle_response client.conditional_create(self, params)
     end
 
+    def base_create(options, format = @@client.default_format)
+      handle_response client.base_create(self, options, format)
+    end
+
     def update
       handle_response client.update(self, id)
     end


### PR DESCRIPTION
Hi Crucible, 

This PR aims at enabling any models to easily expose the `base_create`  method interface. 
We could now write something like : 
`FHIR::Patient.new(name: [human_name]).base_create(options)`

This is very useful when one needs to add specific headers (depending on the FHIR server). 

Let me know what you think it.
Thks