### PR TITLE
Allows to use create method with options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ patient = FHIR::Patient.read('example')
 
 # update a patient
 patient.gender = 'female'
-patient.update # saves the patient 
+patient.update # saves the patient
 
 # create a patient
 patient = FHIR::Patient.create(name: {given: 'John', family: 'Doe'})
+
+#create a patient with specific headers
+patient = FHIR::Patient.new(name: {given: 'John', family: 'Doe'}).create({Prefer: "return=representation"})
 
 # search patients
 results = FHIR::Patient.search(given: 'John', family: 'Doe')

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -51,9 +51,9 @@ module FHIR
       handle_response client.search(self, search: { parameters: params })
     end
 
-    def self.create(model, options = {}, client = @@client)
+    def self.create(model, client = @@client)
       model = new(model) unless model.is_a?(self)
-      handle_response client.create(model, options)
+      handle_response client.create(model)
     end
 
     def self.conditional_create(model, params, client = @@client)
@@ -69,8 +69,8 @@ module FHIR
       self.class.vread(id, version_id, client)
     end
 
-    def create
-      handle_response client.create(self)
+    def create(options = {})
+      handle_response client.create(self, options)
     end
 
     def conditional_create(params)

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -51,9 +51,9 @@ module FHIR
       handle_response client.search(self, search: { parameters: params })
     end
 
-    def self.create(model, client = @@client)
+    def self.create(model, options = {}, client = @@client)
       model = new(model) unless model.is_a?(self)
-      handle_response client.create(model)
+      handle_response client.create(model, options)
     end
 
     def self.conditional_create(model, params, client = @@client)

--- a/lib/fhir_client/sections/crud.rb
+++ b/lib/fhir_client/sections/crud.rb
@@ -117,8 +117,8 @@ module FHIR
       # Create a new resource with a server assigned id. Return the newly created
       # resource with the id the server assigned.
       #
-      def create(resource, format = @default_format)
-        base_create(resource, nil, format)
+      def create(resource, options = {}, format = @default_format)
+        base_create(resource, options, format)
       end
 
       #


### PR DESCRIPTION
  Hi Crucible, 

This PR aims at enabling any models to easily expose the `create`  method with options. 
We could now write something like : 
`FHIR::Patient.new(name: [human_name], options).create(options)`

This is very useful when one needs to add specific headers (depending on the FHIR server). 
Our FHIR server needs  a Prefer header to get the id of the newly created resource on the response payload. 

Let me know what you think it.
Thks