### PR TITLE
History format fix

### DIFF
--- a/lib/fhir_client/sections/history.rb
+++ b/lib/fhir_client/sections/history.rb
@@ -24,8 +24,9 @@ module FHIR
       # public <T extends Resource> AtomFeed history(DateAndTime last_update, Class<T> resourceClass, String id);
 
       def history(options)
+        options = {format: @default_format}.merge(options)
         reply = get resource_url(options), fhir_headers(options).except(:history)
-        reply.resource = parse_reply(options[:resource], @default_format, reply)
+        reply.resource = parse_reply(options[:resource], options[:format], reply)
         reply.resource_class = options[:resource]
         reply
       end

--- a/test/unit/client_interface_sections/history_test.rb
+++ b/test/unit/client_interface_sections/history_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../test_helper'
+
+class ClientInterfaceHistoryTest < Test::Unit::TestCase
+  def client
+    @client ||= FHIR::Client.new('history-test')
+  end
+
+  def test_history_uses_default_json_dstu2
+    stub_request(:get, /history-test/).to_return(body: '{"resourceType":"Bundle"}')
+
+    temp = client
+    temp.use_dstu2
+    temp.default_json
+
+    reply = temp.all_history
+    assert_equal FHIR::Formats::ResourceFormat::RESOURCE_JSON_DSTU2, reply.request[:headers]['format']
+  end
+
+end

--- a/test/unit/client_interface_sections/history_test.rb
+++ b/test/unit/client_interface_sections/history_test.rb
@@ -16,4 +16,37 @@ class ClientInterfaceHistoryTest < Test::Unit::TestCase
     assert_equal FHIR::Formats::ResourceFormat::RESOURCE_JSON_DSTU2, reply.request[:headers]['format']
   end
 
+  def test_history_uses_default_xml_dstu2
+    stub_request(:get, /history-test/).to_return(body: '{"resourceType":"Bundle"}')
+
+    temp = client
+    temp.use_dstu2
+    temp.default_xml
+
+    reply = temp.all_history
+    assert_equal FHIR::Formats::ResourceFormat::RESOURCE_XML_DSTU2, reply.request[:headers]['format']
+  end
+
+  def test_history_uses_default_json_stu3
+    stub_request(:get, /history-test/).to_return(body: '{"resourceType":"Bundle"}')
+
+    temp = client
+    temp.use_stu3
+    temp.default_json
+
+    reply = temp.all_history
+    assert_equal FHIR::Formats::ResourceFormat::RESOURCE_JSON, reply.request[:headers]['format']
+  end
+
+  def test_history_uses_default_xml_stu3
+    stub_request(:get, /history-test/).to_return(body: '{"resourceType":"Bundle"}')
+
+    temp = client
+    temp.use_stu3
+    temp.default_xml
+
+    reply = temp.all_history
+    assert_equal FHIR::Formats::ResourceFormat::RESOURCE_XML, reply.request[:headers]['format']
+  end
+
 end


### PR DESCRIPTION
A bug in `history.rb` caused issues with history requests not using the default format.

This PR fixes this bug, and adds tests for this issue.