### PR TITLE
Fix the fhir:console task in windows.

### DIFF
--- a/lib/fhir_client/tasks/tasks.rake
+++ b/lib/fhir_client/tasks/tasks.rake
@@ -4,7 +4,7 @@ FHIR.logger.level = Logger::ERROR
 namespace :fhir do
   desc 'console'
   task :console, [] do
-    sh 'bin/console'
+    exec('ruby bin/console')
   end
 
   #


### PR DESCRIPTION
Addresses problem identified in #83 by using built in ruby `exec` method.  Tested on Win10 (ruby installed with RubyInstaller) and MacOS.