### PR TITLE
Updated Rubocop to latest version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Layout:
 
 Performance/Casecmp:
   Enabled: false
+
+Naming:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - '*.gemspec'
     - 'Gemfile*'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gemspec
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
-  gem 'rubocop', '~> 0.49.0', require: false
+  gem 'rubocop', '~> 0.56.0', require: false
   gem 'awesome_print', require: 'ap'
 end

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -685,7 +685,7 @@ module FHIR
     end
 
     def build_url(path)
-      if path =~ /^\w+:\/\//
+      if /^\w+:\/\//.match? path
         path
       else
         "#{base_path(path)}#{path}"


### PR DESCRIPTION
Hello guys,

I wanted to fix a few things on your gem (we have an extended use if it as all our infrastructure is FHIR based and some of our clients are Rails apps). As we use ruby 2.5 by default, I had to update Rubocop to it's latest version. Was that the correct choice ?

I fixed a `Performance/RegexpMatch` offense and silenced `Naming` ones as you did.

Here are all the previous offenses: 
![image](https://user-images.githubusercontent.com/639743/40279212-be9c31a8-5c3e-11e8-8414-d13f1470e718.png)

With this PR, `bundle exec rake test` works perfectly in a 2.5.x environment.