### PR TITLE
Access token auth

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -148,13 +148,13 @@ module FHIR
     # client -- client id
     # secret -- client secret
     # options -- hash of options
-    #   access_token: Your current access_token, must have atleast an access_token or a refresh_token
-    #   refresh_token: a token that is used to referesh the access token when it
-    #                  expires, or if one does not exist but can be obtained from
-    #                  the refresh toekn
+    #   access_token: Current access_token
+    #   refresh_token: a token that is used to obtaine an new access_token when it
+    #                  expires or does not currently exist
     #   authorize_path -- absolute path of authorization endpoint
     #   token_path -- absolute path of token endpoint
-    #  Addtional options can be passed in as supported byt the OAuth2::AcessToken class
+    #   auto_configure -- whether or not to configure the oauth endpoints from the servers capability statement
+    #  Addtional options can be passed in as supported by the OAuth2::AcessToken class
     def set_auth_from_token(client, secret, options)
       FHIR.logger.info 'Configuring the client to use OAuth2 access token authentication.'
 

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -149,7 +149,7 @@ module FHIR
     # secret -- client secret
     # options -- hash of options
     #   access_token: Current access_token
-    #   refresh_token: a token that is used to obtaine an new access_token when it
+    #   refresh_token: a token that is used to obtain an new access_token when it
     #                  expires or does not currently exist
     #   authorize_path -- absolute path of authorization endpoint
     #   token_path -- absolute path of token endpoint

--- a/test/unit/client_acess_token_test.rb
+++ b/test/unit/client_acess_token_test.rb
@@ -8,7 +8,7 @@ class ClientAccessTokenTest < Test::Unit::TestCase
 
   def test_can_configure_client_with_access_token_authentication
     # stub out a request for a resource, once configured with the access token
-    # the auth methed would be a bearer token with the provided access token
+    # the auth methed should be a bearer token with the provided access token
     # the stub only works on calls that have the correct authentication header
     stub_request(:get, /Patient\/example/).
                         with(headers:{"Authorization"=>"Bearer some token"}).
@@ -28,7 +28,7 @@ class ClientAccessTokenTest < Test::Unit::TestCase
     stub_request(:post, /auth\/token/).to_return(body: new_token, headers: {"Content-Type" => "application/json"} )
 
     # stub out a request for a resource, once configured with the access token
-    # the auth methed would be a bearer token with the access token retrieved
+    # the auth method should be a bearer token with the access token retrieved
     # from the previous call to get a new access token
     # the stub only works on calls that have the correct authentication header
 
@@ -46,8 +46,8 @@ class ClientAccessTokenTest < Test::Unit::TestCase
     assert_equal "{}", client.read(FHIR::Patient, "example").response[:body]
   end
 
-  # Need to provider at a minimum an access_token or a refresh_token, it can be
-  # both but need atleast one of them, otherwise there is nothing to configure
+  # Need to provide at a minimum an access_token or a refresh_token, it can be
+  # both but need at least one of them, otherwise there is nothing to configure
   # against
   def test_must_supply_either_an_access_token_or_a_refresh_token
     begin
@@ -59,7 +59,7 @@ class ClientAccessTokenTest < Test::Unit::TestCase
   end
 
   # Make sure that we can auto configure the auth and token endpoints from a
-  # capability statement.  
+  # capability statement.
   def test_can_configure_access_token_with_auto_configure
     root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
     capabilitystatement = File.read(File.join(root, 'fixtures', 'oauth_capability_statement.json'))

--- a/test/unit/client_acess_token_test.rb
+++ b/test/unit/client_acess_token_test.rb
@@ -7,7 +7,9 @@ class ClientAccessTokenTest < Test::Unit::TestCase
   end
 
   def test_can_configure_client_with_access_token_authentication
-
+    # stub out a request for a resource, once configured with the access token
+    # the auth methed would be a bearer token with the provided access token
+    # the stub only works on calls that have the correct authentication header
     stub_request(:get, /Patient\/example/).
                         with(headers:{"Authorization"=>"Bearer some token"}).
                         to_return(body: "{}", headers: {"Content-Type" => "application/json"} )
@@ -21,7 +23,15 @@ class ClientAccessTokenTest < Test::Unit::TestCase
 
   def test_can_configure_client_with_refresh_token_for_authentication
     new_token = "{\"access_token\": \"New access Token\"}"
+    # stub request for requesting a new access token from an auth server token endpoint
+    #   this will return the expected new access token
     stub_request(:post, /auth\/token/).to_return(body: new_token, headers: {"Content-Type" => "application/json"} )
+
+    # stub out a request for a resource, once configured with the access token
+    # the auth methed would be a bearer token with the access token retrieved
+    # from the previous call to get a new access token
+    # the stub only works on calls that have the correct authentication header
+
     stub_request(:get, /Patient\/example/).
                         with(headers:{"Authorization"=>"Bearer New access Token"}).
                         to_return(body: "{}", headers: {"Content-Type" => "application/json"} )
@@ -30,10 +40,15 @@ class ClientAccessTokenTest < Test::Unit::TestCase
                                                        expires_in: -1,
                                                        refresh_token: "My Refresh Token",
                                                        token_path: "/auth/token"});
+
     assert_equal "New access Token", token.token
+    # make a call to test the stubbed out method with auth type
     assert_equal "{}", client.read(FHIR::Patient, "example").response[:body]
   end
 
+  # Need to provider at a minimum an access_token or a refresh_token, it can be
+  # both but need atleast one of them, otherwise there is nothing to configure
+  # against
   def test_must_supply_either_an_access_token_or_a_refresh_token
     begin
       client.set_auth_from_token("id","secret", {})
@@ -43,6 +58,8 @@ class ClientAccessTokenTest < Test::Unit::TestCase
     end
   end
 
+  # Make sure that we can auto configure the auth and token endpoints from a
+  # capability statement.  
   def test_can_configure_access_token_with_auto_configure
     root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
     capabilitystatement = File.read(File.join(root, 'fixtures', 'oauth_capability_statement.json'))

--- a/test/unit/client_acess_token_test.rb
+++ b/test/unit/client_acess_token_test.rb
@@ -1,0 +1,59 @@
+require_relative '../test_helper'
+
+class ClientAccessTokenTest < Test::Unit::TestCase
+
+  def client
+    @client ||= FHIR::Client.new("basic-test")
+  end
+
+  def test_can_configure_client_with_access_token_authentication
+
+    stub_request(:get, /Patient\/example/).
+                        with(headers:{"Authorization"=>"Bearer some token"}).
+                        to_return(body: "{}", headers: {"Content-Type" => "application/json"} )
+    client.set_auth_from_token("id","secret", {access_token: "some token",
+                                                auto_configure: false});
+
+
+    assert_equal "{}", client.read(FHIR::Patient, "example").response[:body]
+
+  end
+
+  def test_can_configure_client_with_refresh_token_for_authentication
+    new_token = "{\"access_token\": \"New access Token\"}"
+    stub_request(:post, /auth\/token/).to_return(body: new_token, headers: {"Content-Type" => "application/json"} )
+    stub_request(:get, /Patient\/example/).
+                        with(headers:{"Authorization"=>"Bearer New access Token"}).
+                        to_return(body: "{}", headers: {"Content-Type" => "application/json"} )
+    token = client.set_auth_from_token("id","secret", {access_token: "some token",
+                                                       auto_configure: false,
+                                                       expires_in: -1,
+                                                       refresh_token: "My Refresh Token",
+                                                       token_path: "/auth/token"});
+    assert_equal "New access Token", token.token
+    assert_equal "{}", client.read(FHIR::Patient, "example").response[:body]
+  end
+
+  def test_must_supply_either_an_access_token_or_a_refresh_token
+    begin
+      client.set_auth_from_token("id","secret", {})
+      assert false, "Should not be able to configure client without either an access or refresh token"
+    rescue
+      assert_equal "Must provide an access_token or a refresh_token", $!.message
+    end
+  end
+
+  def test_can_configure_access_token_with_auto_configure
+    root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+    capabilitystatement = File.read(File.join(root, 'fixtures', 'oauth_capability_statement.json'))
+    stub_request(:get, /metadata/).to_return(body: capabilitystatement)
+    token = client.set_auth_from_token("id","secret", {access_token: "some token",
+                                                       auto_configure: true});
+
+    assert_equal "https://authorize.smarthealthit.org/authorize", token.client.options[:authorize_url]
+    assert_equal "https://authorize.smarthealthit.org/token", token.client.options[:token_url]
+  end
+
+
+
+end


### PR DESCRIPTION
Part of the SMART on FHIR specification is the support for clients that operate on behave of a user when the user does not have an active session.  This is accomplished through the use of the SMART offline_access scope which provides the client application with a refresh_token that can be used to obtain a new access_token.  This PR enables the ability of the fhir_client to be configured with a refresh_token that can then be exchanged for an access_token.  