### PR TITLE
Add the partial_update method to crud methods

### DIFF
--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -56,7 +56,7 @@ module FHIR
     end
 
     module ClassMethods
- 
+
       def client
         FHIR::Model.client
       end
@@ -105,6 +105,10 @@ module FHIR
       def conditional_create(model, params, client = self.client)
         model = new(model) unless model.is_a?(self)
         handle_response client.conditional_create(model, params)
+      end
+
+      def partial_update(id, patchset, options = {})
+        handle_response client.partial_update(self, id, patchset, options)
       end
 
       def all(client = self.client)

--- a/test/unit/client_interface_sections/update_test.rb
+++ b/test/unit/client_interface_sections/update_test.rb
@@ -1,0 +1,26 @@
+require_relative '../../test_helper'
+
+class ClientInterfaceUpdateTest < Test::Unit::TestCase
+  def client
+    @client ||= FHIR::Client.new('update-test')
+  end
+
+  def test_class_partial_update
+    patient = FHIR::Patient.new({'id' => 'foo', 'active'=>true})
+    patchset = [
+        {
+          op: "replace",
+          path: "/active/",
+          value: "false"
+        }
+      ]
+
+    outcome = FHIR::OperationOutcome.new({'issue'=>[{'code'=>'informational', 'severity'=>'information', 'diagnostics'=>'Successfully updated "Patient/foo" in 0 ms'}]})
+
+    stub_request(:patch, /Patient\/foo/).with(body: "[{\"op\":\"replace\",\"path\":\"/active/\",\"value\":\"false\"}]").to_return(status: 200, body: outcome.to_json, headers: {'Content-Type'=>'application/fhir+json', 'Location'=>'http://update-test/Patient/foo/_history/0', 'ETag'=>'W/"foo"', 'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    reply = FHIR::Patient.partial_update(patient.id, patchset)
+
+    assert reply.is_a?(FHIR::DSTU2::OperationOutcome)
+  end
+
+end


### PR DESCRIPTION
Hello guys,

we use a PATCH strategy on our resources and we noticed that this method wasn't available on the resource client methods.

We use it the following way:

```ruby
patient = FHIR::Patient.new({'id' => 'foo', 'active'=>true})
patchset = [
    {
      op: "replace",
      path: "/active/",
      value: "false"
    }
  ]

FHIR::Patient.partial_update(patient.id, patchset)
```

I wasn't very sure about what to test on this method, feel free to indicate a better test :)

PS: I tried to implement `patient.partial_update(patchset)` but I ran into an issue in the `fhir_models` gem (not split method)