### PR TITLE
Add the possibility to specify additional headers

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -22,6 +22,7 @@ module FHIR
     attr_accessor :default_format
     attr_accessor :fhir_version
     attr_accessor :cached_capability_statement
+    attr_accessor :additional_headers
 
     # Call method to initialize FHIR client. This method must be invoked
     # with a valid base server URL prior to using the client.
@@ -279,6 +280,8 @@ module FHIR
     end
 
     def fhir_headers(options = {})
+      options.merge!(additional_headers) unless additional_headers.nil?
+
       FHIR::ResourceAddress.new.fhir_headers(options, @use_format_param)
     end
 

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -9,6 +9,20 @@ class BasicTest < Test::Unit::TestCase
     assert !client.use_format_param, 'Using _format instead of [Accept] headers.'
   end
 
+  def test_set_basic_auth_auth
+    client.set_basic_auth('client', 'secret')
+
+    assert client.security_headers == {"Authorization"=>"Basic Y2xpZW50OnNlY3JldA==\n"}
+    assert client.client == RestClient
+  end
+
+  def test_bearer_token_auth
+    client.set_bearer_token('secret_token')
+
+    assert client.security_headers == {"Authorization"=>"Bearer secret_token"}
+    assert client.client == RestClient
+  end
+
   def test_client_logs_without_response
     # This used to provide a NoMethodError:
     # undefined method `request' for nil:NilClass

--- a/test/unit/headers_test.rb
+++ b/test/unit/headers_test.rb
@@ -1,0 +1,15 @@
+require_relative '../test_helper'
+
+class HeadersTest < Test::Unit::TestCase
+  def client
+    @client ||= FHIR::Client.new("headers-test")
+  end
+
+  def test_client_additional_headers
+    client.additional_headers = { "X-API-VERSION" => "1" }
+
+    headers = client.fhir_headers
+
+    assert headers["X-API-VERSION"] == "1"
+  end
+end


### PR DESCRIPTION
Hello,

we've been working for the last weeks on 2 versions of our FHIR API and in order to choose the V1 or the V2 we are using a specific header.

In this PR we add the possibility to specify additional headers on the client. We use this option exactly like in the test:

```ruby
client = FHIR::Client.new("headers-test")
client.additional_headers = { "X-API-VERSION" => "1" }
```

I've also added simple tests on `set_basic_auth` and `set_bearer_token` to help with the spec coverage.

What do you think ?