### PR TITLE
Adds the possibility to vread on a Reference

### DIFF
--- a/lib/fhir_client/ext/reference.rb
+++ b/lib/fhir_client/ext/reference.rb
@@ -8,7 +8,6 @@ module FHIR
       /history/.match reference.to_s
     end
 
-
     def reference_id
       if contained?
         reference.to_s[1..-1]
@@ -28,7 +27,6 @@ module FHIR
          reference.to_s.split('/').last
       end
     end
-
 
     def read
       return if contained? || type.blank? || (id.blank? && reference.blank?)

--- a/lib/fhir_client/ext/reference.rb
+++ b/lib/fhir_client/ext/reference.rb
@@ -4,9 +4,16 @@ module FHIR
       reference.to_s.start_with?('#')
     end
 
+    def has_version?
+      /history/.match reference.to_s
+    end
+
+
     def reference_id
       if contained?
         reference.to_s[1..-1]
+      elsif has_version?
+        reference.to_s.split('/').second
       else
         reference.to_s.split('/').last
       end
@@ -16,11 +23,25 @@ module FHIR
       reference.to_s.split('/').first unless contained?
     end
 
+    def version_id
+      if has_version?
+         reference.to_s.split('/').last
+      end
+    end
+
+
     def read
       return if contained? || type.blank? || (id.blank? && reference.blank?)
       rid = id || reference_id
       resource_class.read(rid, client)
     end
+
+    def vread
+      return if contained? || type.blank? || (id.blank? && reference.blank?) || version_id.blank?
+      rid = id || reference_id
+      resource_class.vread(rid, version_id, client)
+    end
+
   end
 end
 
@@ -38,7 +59,7 @@ module FHIR
   module DSTU2
     class Reference
       include FHIR::ReferenceExtras
-      
+
       def resource_class
         "FHIR::DSTU2::#{type}".constantize unless contained?
       end

--- a/test/unit/reference_extras_test.rb
+++ b/test/unit/reference_extras_test.rb
@@ -60,4 +60,14 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert res.is_a?(FHIR::Patient)
   end
 
+  def test_vread_reference
+    stub_request(:get, /extras/).to_return(body: FHIR::Patient.new.to_json)
+    client = FHIR::Client.new('extras')
+    client.default_json
+    FHIR::Model.client = client
+    ref = FHIR::Reference.new({'reference': 'Patient/foo/_history/6'})
+    res = ref.vread
+    assert res.is_a?(FHIR::Patient)
+  end
+
 end


### PR DESCRIPTION
Hello,

this PR is more a question, we noticed that we could use this syntax:

```ruby
FHIR::Reference.new({'reference': 'Patient/foo'}).read
``` 

but as we use history a lot I was wondering if this strategy is acceptable to you:

```ruby
FHIR::Reference.new({'reference': 'Patient/foo/_history/6'}).vread
``` 

Cheers