### PR TITLE
Added the possibility to specify a custom OAuth2 url

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ options = client.get_oauth2_metadata_from_conformance
 if options.empty?
   puts 'This server does not support the expected OAuth2 extensions.'
 else
-  client.set_oauth2_auth(client_id,client_secret,options[:site],options[:authorize_url],options[:token_url])
+  client.set_oauth2_auth(client_id, client_secret, options[:authorize_url] ,options[:token_url], options[:site])
   reply = client.read_feed(FHIR::Patient)
   puts reply.body
 end

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -130,13 +130,13 @@ module FHIR
     # secret -- client secret
     # authorize_path -- absolute path of authorization endpoint
     # token_path -- absolute path of token endpoint
-    def set_oauth2_auth(client, secret, authorize_path, token_path)
+    def set_oauth2_auth(client, secret, authorize_path, token_path, site = nil)
       FHIR.logger.info 'Configuring the client to use OpenID Connect OAuth2 authentication.'
       @use_oauth2_auth = true
       @use_basic_auth = false
       @security_headers = {}
       options = {
-        site: @base_service_url,
+        site: site || @base_service_url,
         authorize_url: authorize_path,
         token_url: token_path,
         raise_errors: true

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -52,21 +52,6 @@ class BasicTest < Test::Unit::TestCase
     assert client.client.client.site == "http://custom-test.com/fhir/"
   end
 
-  # def set_oauth2_auth(client, secret, authorize_path, token_path, site = nil)
-  #     FHIR.logger.info 'Configuring the client to use OpenID Connect OAuth2 authentication.'
-  #     @use_oauth2_auth = true
-  #     @use_basic_auth = false
-  #     @security_headers = {}
-  #     options = {
-  #       site: site || @base_service_url,
-  #       authorize_url: authorize_path,
-  #       token_url: token_path,
-  #       raise_errors: true
-  #     }
-  #     client = OAuth2::Client.new(client, secret, options)
-  #     @client = client.client_credentials.get_token
-  #   end
-
   def test_client_logs_without_response
     # This used to provide a NoMethodError:
     # undefined method `request' for nil:NilClass

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -2,7 +2,7 @@ require_relative '../test_helper'
 
 class BasicTest < Test::Unit::TestCase
   def client
-    @client ||= FHIR::Client.new("basic-test")
+    @client ||= FHIR::Client.new("http://basic-test.com/fhir/")
   end
 
   def test_client_initialization
@@ -12,6 +12,8 @@ class BasicTest < Test::Unit::TestCase
   def test_set_basic_auth_auth
     client.set_basic_auth('client', 'secret')
 
+    assert client.use_oauth2_auth == false
+    assert client.use_basic_auth == true
     assert client.security_headers == {"Authorization"=>"Basic Y2xpZW50OnNlY3JldA==\n"}
     assert client.client == RestClient
   end
@@ -19,9 +21,51 @@ class BasicTest < Test::Unit::TestCase
   def test_bearer_token_auth
     client.set_bearer_token('secret_token')
 
+    assert client.use_oauth2_auth == false
+    assert client.use_basic_auth == true
     assert client.security_headers == {"Authorization"=>"Bearer secret_token"}
     assert client.client == RestClient
+
   end
+
+  def test_oauth2_token_auth
+    stub_request(:post, /token_path/).to_return(status: 200, body: '{"access_token" : "valid_token"}', headers: {'Content-Type' => 'application/json'})
+
+    client.set_oauth2_auth("client", "secret", "authorize_path", "token_path")
+
+    assert client.use_oauth2_auth == true
+    assert client.use_basic_auth == false
+    assert client.security_headers == {}
+
+    assert client.client.client.site == "http://basic-test.com/fhir/"
+  end
+
+  def test_oauth2_token_auth_custom
+    stub_request(:post, /token_path/).to_return(status: 200, body: '{"access_token" : "valid_token"}', headers: {'Content-Type' => 'application/json'})
+
+    client.set_oauth2_auth("client", "secret", "authorize_path", "token_path", "http://custom-test.com/fhir/")
+
+    assert client.use_oauth2_auth == true
+    assert client.use_basic_auth == false
+    assert client.security_headers == {}
+
+    assert client.client.client.site == "http://custom-test.com/fhir/"
+  end
+
+  # def set_oauth2_auth(client, secret, authorize_path, token_path, site = nil)
+  #     FHIR.logger.info 'Configuring the client to use OpenID Connect OAuth2 authentication.'
+  #     @use_oauth2_auth = true
+  #     @use_basic_auth = false
+  #     @security_headers = {}
+  #     options = {
+  #       site: site || @base_service_url,
+  #       authorize_url: authorize_path,
+  #       token_url: token_path,
+  #       raise_errors: true
+  #     }
+  #     client = OAuth2::Client.new(client, secret, options)
+  #     @client = client.client_credentials.get_token
+  #   end
 
   def test_client_logs_without_response
     # This used to provide a NoMethodError:


### PR DESCRIPTION
We do not use the same domain for our OAuth2 logic but the current strategy was to use the `base_service_url` as the `site` attribute for the OAuth2 client.
I noticed in the Readme that you were using the `options[:site]` in the `set_oauth2_auth` which was not defined.

This PR fixes the `set_oauth2_auth` to be able to specify a custom `site` attribute for the OAuth2 client and adds a little bit more spec coverage on this strategy.