### PR TITLE
Added the possibility to set a proxy URL for the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ patient = FHIR::DSTU2::Patient.read('example')
 patient = client.read(FHIR::DSTU2::Patient, 'example').resource
 ```
 
+### Configuration
+
+You can specify additional properties for the `client`:
+
+```ruby
+client.additional_headers = {Prefer: 'return=representation'}
+client.proxy = 'https://your-proxy.com/'
+```
+
 ### CRUD Examples
 ```ruby
 # read an existing patient with id "example"

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -23,7 +23,7 @@ module FHIR
     attr_accessor :fhir_version
     attr_accessor :cached_capability_statement
     attr_accessor :additional_headers
-    attr_accessor :proxy_url
+    attr_accessor :proxy
 
     # Call method to initialize FHIR client. This method must be invoked
     # with a valid base server URL prior to using the client.

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -103,7 +103,7 @@ module FHIR
       @use_basic_auth = false
       @security_headers = {}
       @client = RestClient
-      @client.proxy = proxy_url unless proxy_url.nil?
+      @client.proxy = proxy unless proxy.nil?
       @client
     end
 
@@ -116,7 +116,7 @@ module FHIR
       @use_oauth2_auth = false
       @use_basic_auth = true
       @client = RestClient
-      @client.proxy = proxy_url unless proxy_url.nil?
+      @client.proxy = proxy unless proxy.nil?
       @client
     end
 
@@ -128,7 +128,7 @@ module FHIR
       @use_oauth2_auth = false
       @use_basic_auth = true
       @client = RestClient
-      @client.proxy = proxy_url unless proxy_url.nil?
+      @client.proxy = proxy unless proxy.nil?
       @client
     end
 
@@ -149,7 +149,7 @@ module FHIR
         raise_errors: true
       }
       client = OAuth2::Client.new(client, secret, options)
-      client.connection.proxy(proxy_url) unless proxy_url.nil?
+      client.connection.proxy(proxy) unless proxy.nil?
       @client = client.client_credentials.get_token
     end
 

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -23,6 +23,7 @@ module FHIR
     attr_accessor :fhir_version
     attr_accessor :cached_capability_statement
     attr_accessor :additional_headers
+    attr_accessor :proxy_url
 
     # Call method to initialize FHIR client. This method must be invoked
     # with a valid base server URL prior to using the client.
@@ -102,6 +103,8 @@ module FHIR
       @use_basic_auth = false
       @security_headers = {}
       @client = RestClient
+      @client.proxy = proxy_url unless proxy_url.nil?
+      @client
     end
 
     # Set the client to use HTTP Basic Authentication
@@ -113,6 +116,8 @@ module FHIR
       @use_oauth2_auth = false
       @use_basic_auth = true
       @client = RestClient
+      @client.proxy = proxy_url unless proxy_url.nil?
+      @client
     end
 
     # Set the client to use Bearer Token Authentication
@@ -123,6 +128,8 @@ module FHIR
       @use_oauth2_auth = false
       @use_basic_auth = true
       @client = RestClient
+      @client.proxy = proxy_url unless proxy_url.nil?
+      @client
     end
 
     # Set the client to use OpenID Connect OAuth2 Authentication
@@ -142,6 +149,7 @@ module FHIR
         raise_errors: true
       }
       client = OAuth2::Client.new(client, secret, options)
+      client.connection.proxy(proxy_url) unless proxy_url.nil?
       @client = client.client_credentials.get_token
     end
 

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -32,12 +32,13 @@ module FHIR
     # @param default_format Default Format Mime type
     # @return
     #
-    def initialize(base_service_url, default_format: FHIR::Formats::ResourceFormat::RESOURCE_XML)
+    def initialize(base_service_url, default_format: FHIR::Formats::ResourceFormat::RESOURCE_XML, proxy: nil)
       @base_service_url = base_service_url
       FHIR.logger.info "Initializing client with #{@base_service_url}"
       @use_format_param = false
       @default_format = default_format
       @fhir_version = :stu3
+      @proxy = proxy
       set_no_auth
     end
 

--- a/lib/fhir_client/ext/reference.rb
+++ b/lib/fhir_client/ext/reference.rb
@@ -59,7 +59,7 @@ module FHIR
       if relative? || reference == client.full_resource_url(resource: resource_class, id: reference_id)
         read_client = client
       else
-        read_client = FHIR::Client.new base_uri, default_format: client.default_format
+        read_client = FHIR::Client.new base_uri, default_format: client.default_format, proxy: client.proxy
       end
       resource_class.read(reference_id, read_client)
     end
@@ -69,7 +69,7 @@ module FHIR
       if relative? || reference == client.full_resource_url(resource: resource_class, id: reference_id)
         read_client = client
       else
-        read_client = FHIR::Client.new base_uri, default_format: client.default_format
+        read_client = FHIR::Client.new base_uri, default_format: client.default_format, proxy: client.proxy
       end
       resource_class.vread(reference_id, version_id, read_client)
     end


### PR DESCRIPTION
This PR adds an attribute `proxy_url` to the `FHIR::Client` object. It helps set up a proxy URL.

For the `RestClient` strategy, it was possible to define it after setting the strategy, for the `OAuth2::Client` it was needed inside in order to provide this configuration before retrieving the token.