### PR TITLE
Removing invalid "RUBY_VERSION" Ruby version string from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby RUBY_VERSION
 
 # gem 'fhir_models', :path => '../fhir_models'
 # gem 'fhir_dstu2_models', :path => '../fhir_dstu2_models'


### PR DESCRIPTION
The Gemfile specifies the exact required ruby version as "RUBY_VERSION"
which is not a ruby version. Unless there's some hidden Ruby version
requirement of this Gem, I don't see a point in keeping it?

This is the warning RVM spits out for every Terminal action:

    RVM used your Gemfile for selecting Ruby, it is all fine - Heroku does that too,
    you can ignore these warnings with 'rvm rvmrc warning ignore fhir_client/Gemfile'.
    To ignore the warning for all files run 'rvm rvmrc warning ignore allGemfiles'.

    Unknown ruby interpreter version (do not know how to handle): RUBY_VERSION.