### PR TITLE
Fix up reference resolution and update unit tests

### DIFF
--- a/test/unit/reference_extras_test.rb
+++ b/test/unit/reference_extras_test.rb
@@ -42,6 +42,26 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert r.resource_class == FHIR::DSTU2::Patient
   end
 
+  def test_relative
+    r = FHIR::Reference.new({'reference': 'Patient/foo'})
+    assert r.relative?
+  end
+
+  def test_relative_dstu2
+    r = FHIR::DSTU2::Reference.new({'reference': 'Patient/foo'})
+    assert r.relative?
+  end
+
+  def test_absolute
+    r = FHIR::Reference.new({'reference': 'http://hapi.fhir.org/baseDstu3/Patient/foo'})
+    assert r.absolute?
+  end
+
+  def test_absolute_dstu2
+    r = FHIR::DSTU2::Reference.new({'reference': 'http://hapi.fhir.org.baseDstu2/Patient/foo'})
+    assert r.absolute?
+  end
+
   def test_read_contained
     stub_request(:get, /extras/).to_return(body: FHIR::Patient.new.to_json)
     client = FHIR::Client.new('extras')
@@ -50,9 +70,9 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert FHIR::Reference.new({'reference': '#foo'}).read.nil?
   end
 
-  def test_read_reference
-    stub_request(:get, /extras/).to_return(body: FHIR::Patient.new.to_json)
-    client = FHIR::Client.new('extras')
+  def test_read_reference_relative
+    stub_request(:get, 'https://my-server.com/fhir/Patient/foo').to_return(body: FHIR::Patient.new.to_json)
+    client = FHIR::Client.new('https://my-server.com/fhir')
     client.default_json
     FHIR::Model.client = client
     ref = FHIR::Reference.new({'reference': 'Patient/foo'})
@@ -60,14 +80,42 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert res.is_a?(FHIR::Patient)
   end
 
+  def test_read_reference_absolute_same_base
+    stub_request(:get, 'https://my-server.com/fhir/Patient/foo').to_return(body: FHIR::Patient.new.to_json)
+    client = FHIR::Client.new('https://my-server.com/fhir')
+    client.default_json
+    FHIR::Model.client = client
+    ref = FHIR::Reference.new({'reference': 'https://my-server.com/fhir/Patient/foo'})
+    res = ref.read
+    assert res.is_a?(FHIR::Patient)
+    assert client == res.client
+  end
+
+  def test_read_reference_absolute_different_base
+    stub_request(:get, 'https://external-server.com/fhir/Patient/foo').to_return(body: FHIR::Patient.new.to_json)
+    client = FHIR::Client.new('https://my-server.com/fhir')
+    client.default_json
+    FHIR::Model.client = client
+    ref = FHIR::Reference.new({'reference': 'https://external-server.com/fhir/Patient/foo'})
+    res = ref.read
+    assert res.is_a?(FHIR::Patient)
+    assert client != res.client
+  end
+
   def test_vread_reference
-    stub_request(:get, /extras/).to_return(body: FHIR::Patient.new.to_json)
-    client = FHIR::Client.new('extras')
+    stub_request(:get, 'https://my-server.com/fhir/Patient/foo/_history/6').to_return(body: FHIR::Patient.new.to_json)
+    client = FHIR::Client.new('https://my-server.com/fhir')
     client.default_json
     FHIR::Model.client = client
     ref = FHIR::Reference.new({'reference': 'Patient/foo/_history/6'})
     res = ref.vread
     assert res.is_a?(FHIR::Patient)
+  end
+
+  def test_logical_reference
+    ref = FHIR::Reference.new({'identifier': {'resourceType': 'Identifier'}})
+    res = ref.read
+    assert res.nil?
   end
 
 end


### PR DESCRIPTION
The current non-contained reference resolution mechanisms need some work. For example, absolute references are not handled, and the `id` property of the reference (if it exists) is used as the ID of the referenced resource when it shouldn't be. This PR aims to improve reference resolution.

Some points on absolute references:
- Any absolute references are assumed to a reference to an actual FHIR resource, although [this isn't necessarily the case](https://www.hl7.org/fhir/references.html#literal)
- The existing client is reused if the base FHIR URI matches (i.e. treated identically to relative references)
- If the base FHIR URI differs, a new client is created with the same default format, but without any of the previous authentication
 
As a side note, would it make sense for the client to determine the content type of the FHIR resource from the response headers rather than relying on the user to select one beforehand?