### PR TITLE
Added the possibility to inject a different Exception class

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -23,6 +23,7 @@ module FHIR
     attr_accessor :fhir_version
     attr_accessor :cached_capability_statement
     attr_accessor :additional_headers
+    attr_accessor :exception_class
 
     # Call method to initialize FHIR client. This method must be invoked
     # with a valid base server URL prior to using the client.
@@ -35,6 +36,7 @@ module FHIR
       @base_service_url = base_service_url
       FHIR.logger.info "Initializing client with #{@base_service_url}"
       @use_format_param = false
+      @exception_class = ClientException
       @default_format = default_format
       @fhir_version = :stu3
       set_no_auth

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -50,7 +50,7 @@ module FHIR
 
       private
       def handle_response(response)
-        raise ClientException.new "Server returned #{response.code}.", response if response.code.between?(400, 599)
+        raise client.exception_class.new "Server returned #{response.code}.", response if response.code.between?(400, 599)
         response.resource
       end
     end
@@ -66,59 +66,59 @@ module FHIR
       end
 
       def read(id, client = self.client)
-        handle_response client.read(self, id)
+        handle_response client.exception_class, client.read(self, id)
       end
 
       def read_with_summary(id, summary, client = self.client)
-        handle_response client.read(self, id, client.default_format, summary)
+        handle_response client.exception_class, client.read(self, id, client.default_format, summary)
       end
 
       def vread(id, version_id, client = self.client)
-        handle_response client.vread(self, id, version_id)
+        handle_response client.exception_class, client.vread(self, id, version_id)
       end
 
       def resource_history(client = self.client)
-        handle_response client.resource_history(self)
+        handle_response client.exception_class, client.resource_history(self)
       end
 
       def resource_history_as_of(last_update, client = self.client)
-        handle_response client.resource_history_as_of(self, last_update)
+        handle_response client.exception_class, client.resource_history_as_of(self, last_update)
       end
 
       def resource_instance_history(id, client = self.client)
-        handle_response client.resource_instance_history(self, id)
+        handle_response client.exception_class, client.resource_instance_history(self, id)
       end
 
       def resource_instance_history_as_of(id, last_update, client = self.client)
-        handle_response client.resource_instance_history_as_of(self, id, last_update)
+        handle_response client.exception_class, client.resource_instance_history_as_of(self, id, last_update)
       end
 
       def search(params = {}, client = self.client)
-        handle_response client.search(self, search: { parameters: params })
+        handle_response client.exception_class, client.search(self, search: { parameters: params })
       end
 
       def create(model, client = self.client)
         model = new(model) unless model.is_a?(self)
-        handle_response client.create(model)
+        handle_response client.exception_class, client.create(model)
       end
 
       def conditional_create(model, params, client = self.client)
         model = new(model) unless model.is_a?(self)
-        handle_response client.conditional_create(model, params)
+        handle_response client.exception_class, client.conditional_create(model, params)
       end
 
       def partial_update(id, patchset, options = {})
-        handle_response client.partial_update(self, id, patchset, options)
+        handle_response client.exception_class, client.partial_update(self, id, patchset, options)
       end
 
       def all(client = self.client)
-        handle_response client.read_feed(self)
+        handle_response client.exception_class, client.read_feed(self)
       end
 
       private
 
-      def handle_response(response)
-        raise ClientException.new "Server returned #{response.code}.", response if response.code.between?(400, 599)
+      def handle_response(exception_class, response)
+        raise exception_class.new "Server returned #{response.code}.", response if response.code.between?(400, 599)
         response.resource
       end
     end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+
+class TestUnitCustomException < ClientException ; end
+
+class ModelTest < Test::Unit::TestCase
+
+  def test_default_exception
+    stub_request(:post, /create/).to_return(status: 403, body: "")
+    client = FHIR::Client.new('create')
+    client.default_json
+    FHIR::Model.client = client
+
+    assert_raise ClientException do
+      FHIR::Patient.new({'id':'foo'}).create
+    end
+  end
+
+  def test_custom_exception
+    stub_request(:post, /create/).to_return(status: 403, body: "")
+    client = FHIR::Client.new('create')
+    client.default_json
+    client.exception_class = TestUnitCustomException
+    FHIR::Model.client = client
+
+    assert_raise TestUnitCustomException do
+      FHIR::Patient.new({'id':'foo'}).create
+    end
+  end
+end
+


### PR DESCRIPTION
When our FHIR server triggers an error we would like to enrich the Exception with additional elements like trace IDs or some part of the response when possible.

Currently the exception class can't be configured and "defaults" to `ClientException `. We've been monkey patching this class to achieve our needs but we think it could be a good idea to easily allow the configuration of another exception class.

What do you think of this approach ?