### PR TITLE
History bundle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - '*.gemspec'
     - 'Gemfile*'

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -322,7 +322,7 @@ module FHIR
       return nil unless [200, 201].include? response.code
       res = nil
       begin
-        res = if(@fhir_version == :dstu2 || klass.ancestors.include?(FHIR::DSTU2::Model))
+        res = if(@fhir_version == :dstu2 || klass&.ancestors&.include?(FHIR::DSTU2::Model))
                 if(format.include?('xml'))
                   FHIR::DSTU2::Xml.from_xml(response.body)
                 else

--- a/lib/fhir_client/sections/history.rb
+++ b/lib/fhir_client/sections/history.rb
@@ -26,7 +26,15 @@ module FHIR
       def history(options)
         options = {format: @default_format}.merge(options)
         reply = get resource_url(options), fhir_headers
-        reply.resource = parse_reply(options[:resource], options[:format], reply)
+
+        # The history reply should be a bundle
+        bundle_klass = if @fhir_version == :stu3
+                  FHIR::Bundle
+                else
+                  FHIR::DSTU2::Bundle
+                end
+
+        reply.resource = parse_reply(bundle_klass, options[:format], reply)
         reply.resource_class = options[:resource]
         reply
       end

--- a/lib/fhir_client/sections/history.rb
+++ b/lib/fhir_client/sections/history.rb
@@ -29,10 +29,10 @@ module FHIR
 
         # The history reply should be a bundle
         bundle_klass = if @fhir_version == :stu3
-                  FHIR::Bundle
-                else
-                  FHIR::DSTU2::Bundle
-                end
+                         FHIR::Bundle
+                       else
+                         FHIR::DSTU2::Bundle
+                       end
 
         reply.resource = parse_reply(bundle_klass, options[:format], reply)
         reply.resource_class = options[:resource]

--- a/lib/fhir_client/version.rb
+++ b/lib/fhir_client/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   class Client
-    VERSION = '3.1.0'
+    VERSION = '3.1.1'
   end
 end


### PR DESCRIPTION
History parses requests expecting the wrong resource type.  This caused some warnings to pop up in the log.  This also fixes the history_all issue where no resource was passed to the parse_reply method, causing an error. 