### PR TITLE
Add charset parameter to Content-Type Header

### DIFF
--- a/lib/fhir_client/resource_address.rb
+++ b/lib/fhir_client/resource_address.rb
@@ -79,6 +79,9 @@ module FHIR
       # ,but an accept header is explicitly supplied then it will be used (or override the existing)
       fhir_headers.merge!(headers) unless headers.empty?
       fhir_headers.merge!(additional_headers)
+      if /\Aapplication\/(fhir\+xml|xml\+fhir|fhir\+json|json\+fhir)\z/.match? fhir_headers['Content-Type']
+        fhir_headers['Content-Type'] << ";charset=#{DEFAULT_CHARSET}"
+      end
       fhir_headers
     end
 

--- a/lib/fhir_client/sections/crud.rb
+++ b/lib/fhir_client/sections/crud.rb
@@ -187,7 +187,7 @@ module FHIR
         end
         query = query[0..-2] # strip off the trailing ampersand
         header = {if_none_exist: query}
-        base_create(resource, options, format, header)
+        base_create(resource, nil, format, header)
       end
 
       #

--- a/test/unit/client_interface_sections/create_test.rb
+++ b/test/unit/client_interface_sections/create_test.rb
@@ -9,7 +9,15 @@ class ClientInterfaceCreateTest < Test::Unit::TestCase
     patient = FHIR::Patient.new({'gender'=>'female', 'active'=>true, 'deceasedBoolean'=>false})
     outcome = FHIR::OperationOutcome.new({'issue'=>[{'code'=>'informational', 'severity'=>'information', 'diagnostics'=>'Successfully created "Patient/foo" in 0 ms'}]})
 
-    stub_request(:post, /create-test/).to_return(status: 201, body: outcome.to_xml, headers: {'Content-Type'=>'application/fhir+xml', 'Location'=>'http://create-test/Patient/foo/_history/0', 'ETag'=>'W/"foo"', 'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    stub_request(:post, /create-test/)
+        .with(headers: {'Content-Type'=>'application/fhir+xml;charset=utf-8'})
+        .to_return(status: 201,
+                   body: outcome.to_xml,
+                   headers: {'Content-Type'=>'application/fhir+xml',
+                             'Location'=>'http://create-test/Patient/foo/_history/0',
+                             'ETag'=>'W/"foo"',
+                             'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    client.default_xml
     reply = client.create(patient)
     assert reply.resource.is_a?(FHIR::OperationOutcome)
     assert reply.resource_class == FHIR::Patient
@@ -22,7 +30,15 @@ class ClientInterfaceCreateTest < Test::Unit::TestCase
     patient = FHIR::Patient.new({'gender'=>'female', 'active'=>true, 'deceasedBoolean'=>false})
     outcome = FHIR::OperationOutcome.new({'issue'=>[{'code'=>'informational', 'severity'=>'information', 'diagnostics'=>'Successfully created "Patient/foo" in 0 ms'}]})
 
-    stub_request(:post, /create-test/).to_return(status: 201, body: outcome.to_json, headers: {'Content-Type'=>'application/fhir+json', 'Location'=>'http://create-test/Patient/foo/_history/0', 'ETag'=>'W/"foo"', 'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    stub_request(:post, /create-test/)
+        .with(headers: {'Content-Type'=>'application/fhir+json;charset=utf-8'})
+        .to_return(status: 201,
+                   body: outcome.to_json,
+                   headers: {'Content-Type'=>'application/fhir+json',
+                             'Location'=>'http://create-test/Patient/foo/_history/0',
+                             'ETag'=>'W/"foo"',
+                             'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    client.default_json
     reply = client.create(patient)
     assert reply.resource.is_a?(FHIR::OperationOutcome)
     assert reply.resource_class == FHIR::Patient
@@ -34,7 +50,13 @@ class ClientInterfaceCreateTest < Test::Unit::TestCase
   def test_create_response_blank
     patient = FHIR::Patient.new({'gender'=>'female', 'active'=>true, 'deceasedBoolean'=>false})
 
-    stub_request(:post, /create-test/).to_return(status: 201, headers: {'Location'=>'http://create-test/Patient/foo/_history/0', 'ETag'=>'W/"foo"', 'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    stub_request(:post, /create-test/)
+        .with(headers: {'Content-Type'=>'application/fhir+xml;charset=utf-8'})
+        .to_return(status: 201,
+                   headers: {'Location'=>'http://create-test/Patient/foo/_history/0',
+                             'ETag'=>'W/"foo"',
+                             'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    client.default_xml
     reply = client.create(patient)
     assert reply.resource.is_a?(FHIR::Patient)
     assert reply.resource_class == FHIR::Patient

--- a/test/unit/client_interface_sections/read_test.rb
+++ b/test/unit/client_interface_sections/read_test.rb
@@ -67,4 +67,22 @@ class ClientInterfaceReadTest < Test::Unit::TestCase
     assert reply.id == 'foo'
     check_header_keys reply
   end
+
+  def test_raw_read
+    patient = FHIR::Patient.new({'gender'=>'female', 'active'=>true, 'deceasedBoolean'=>false})
+    stub_request(:get, /read-test/)
+        .to_return(status: 200,
+                   body: patient.to_json,
+                   headers: {'Content-Type'=>'application/fhir+json',
+                             'ETag'=>'W/"foo"',
+                             'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
+    temp = client
+    temp.use_stu3
+    temp.default_json
+    options = {resource: FHIR::Patient, id: 'foo'}
+    reply = temp.raw_read(options)
+    returned_resource = temp.parse_reply(FHIR::Patient, FHIR::Formats::ResourceFormat::RESOURCE_JSON, reply)
+    assert returned_resource.is_a?(FHIR::Patient)
+    assert returned_resource.gender == 'female'
+  end
 end

--- a/test/unit/client_interface_sections/update_test.rb
+++ b/test/unit/client_interface_sections/update_test.rb
@@ -37,7 +37,7 @@ class ClientInterfaceUpdateTest < Test::Unit::TestCase
   def test_update
     FHIR::Model.client = client
     patient = FHIR::Patient.new({'id' => 'foo', 'active'=>true})
-    stub_request(:put, /update-test\/Patient\/foo/).with(headers: {'Content-Type'=>'application/json+fhir'}).to_return(status: 200)
+    stub_request(:put, /update-test\/Patient\/foo/).with(headers: {'Content-Type'=>'application/json+fhir;charset=utf-8'}).to_return(status: 200)
     reply = client.update(patient, 'foo')
     check_header_keys reply
     assert reply.code == 200


### PR DESCRIPTION
Appends the `charset` parameter to the `Content-Type` header 

In STU3:
"requests and responses **SHALL explicitly** set the character encoding to UTF-8 using the charset parameter of the MIME-type in the **Content-Type** header."

Note the parameter is not explicitly required in R4:

"UTF-8 encoding **SHALL be used** for the mime type application/fhir. This **MAY be specified as a MIME type parameter** to the application/fhir mime type, but is not required."

e.g.
`Content-Type: application/fhir+json`
will now be
`Content-Type: application/fhir+json;charset=utf-8`

Also updates some of the existing tests to look for the correct `Content-Type` header

See:

[STU3 MIME Type](https://www.hl7.org/fhir/STU3/http.html#mime-type)
[DSTU2 MIME Type](https://www.hl7.org/fhir/DSTU2/http.html#mime-type)
[R4 MIME Type](https://www.hl7.org/fhir/http.html#mime-type)


Also adds a small fix and unit test for conditional_create