### PR TITLE
Fix fhir::count task

### DIFF
--- a/lib/fhir_client/tasks/tasks.rake
+++ b/lib/fhir_client/tasks/tasks.rake
@@ -46,7 +46,7 @@ namespace :fhir do
     fhir_resources.each do |klass|
       reply = client.read_feed(klass)
       total = reply.resource.nil? ? 0 : reply.resource.total
-      total = reply.resource.each.reduce(0) { |s| s += 1 } if total.nil?
+      total = reply.resource.each.reduce(0) { |s| s + 1 } if total.nil?
       if total > 0 || display_zero
         counts[klass.name.demodulize.to_s] = total
       end

--- a/lib/fhir_client/tasks/tasks.rake
+++ b/lib/fhir_client/tasks/tasks.rake
@@ -38,17 +38,19 @@ namespace :fhir do
   end
 
   desc 'count all resources for a given server'
-  task :count, [:url, :display_zero] do |_t, args|
+  task :count, [:url, :display_zero, :include_all] do |_t, args|
     client = FHIR::Client.new(args.url)
     client.try_conformance_formats(FHIR::Formats::ResourceFormat::RESOURCE_JSON)
     display_zero = (args.display_zero == 'true')
+    include_all = (args.include_all == 'true')
     counts = {}
     fhir_resources.each do |klass|
       reply = client.read_feed(klass)
       total = reply.resource.nil? ? 0 : reply.resource.total
-      total = reply.resource.each.reduce(0) { |s| s + 1 } if total.nil?
-      if total > 0 || display_zero
-        counts[klass.name.demodulize.to_s] = total
+      total = reply.resource.each.reduce(0) { |s| s + 1 } if total.nil? && include_all
+      total = 'n/a' if total.nil?
+      if total.to_s != "0" || display_zero
+        counts[klass.name.demodulize.to_s] = total.to_s
       end
     end
     format = "  %-35s %7s\n"

--- a/lib/fhir_client/tasks/tasks.rake
+++ b/lib/fhir_client/tasks/tasks.rake
@@ -45,15 +45,17 @@ namespace :fhir do
     counts = {}
     fhir_resources.each do |klass|
       reply = client.read_feed(klass)
-      if !reply.resource.nil? && (reply.resource.total > 0 || display_zero)
-        counts[klass.name.demodulize.to_s] = reply.resource.total
+      total = reply.resource.nil? ? 0 : reply.resource.total
+      total = reply.resource.each.reduce(0) { |s| s += 1 } if total.nil?
+      if total > 0 || display_zero
+        counts[klass.name.demodulize.to_s] = total
       end
     end
-    printf "  %-30s %5s\n", 'Resource', 'Count'
-    printf "  %-30s %5s\n", '--------', '-----'
+    printf "  %-35s %7s\n", 'Resource', 'Count'
+    printf "  %-35s %7s\n", '--------', '-----'
     counts.each do |key, value|
       # puts "#{key}  #{value}"
-      printf "  %-30s %5s\n", key, value
+      printf "  %-35s %7s\n", key, value
     end
   end
 

--- a/lib/fhir_client/tasks/tasks.rake
+++ b/lib/fhir_client/tasks/tasks.rake
@@ -51,11 +51,11 @@ namespace :fhir do
         counts[klass.name.demodulize.to_s] = total
       end
     end
-    printf "  %-35s %7s\n", 'Resource', 'Count'
-    printf "  %-35s %7s\n", '--------', '-----'
+    format = "  %-35s %7s\n"
+    printf format, 'Resource', 'Count'
+    printf format, '--------', '-----'
     counts.each do |key, value|
-      # puts "#{key}  #{value}"
-      printf "  %-35s %7s\n", key, value
+      printf format, key, value
     end
   end
 


### PR DESCRIPTION
Using an R4 [hapi-fhir-jpaserver-starter](https://github.com/hapifhir/hapi-fhir-jpaserver-starter) server and got this error when running the **fhir::count** task
> rake aborted!
> NoMethodError: undefined method `>' for nil:NilClass
> lib/fhir_client/tasks/tasks.rake:48:in `block (3 levels) in <top (required)>'
> lib/fhir_client/tasks/tasks.rake:46:in `each'
> lib/fhir_client/tasks/tasks.rake:46:in `block (2 levels) in <top (required)>'
> /home/bobn/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
> /home/bobn/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
> Tasks: TOP => fhir:count

The Bundle object only has a total when there are no entries so the entry count needs to be calculated when there are.

I'm not sure if this fix is specific to R4 so may break with older server responses (which I did not test). I.e. maybe this change needs to be made conditional based on server version?

I could not find any tests for the rake tasks.
