### PR TITLE
Add Support for x-www-form-urlencoded payloads

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -384,6 +384,10 @@ module FHIR
           resource.to_xml
         elsif format_specified.downcase.include?('json')
           resource.to_json
+        elsif format_specified.downcase.include?('urlencoded')
+          resource.map do |k,v|
+            "#{k}=#{v}"
+          end.join('&')
         else
           resource.to_xml
         end

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -385,9 +385,7 @@ module FHIR
         elsif format_specified.downcase.include?('json')
           resource.to_json
         elsif format_specified.downcase.include?('urlencoded')
-          resource.map do |k,v|
-            "#{k}=#{v}"
-          end.join('&')
+          URI.encode_www_form(resource)
         else
           resource.to_xml
         end

--- a/test/unit/client_interface_sections/search_test.rb
+++ b/test/unit/client_interface_sections/search_test.rb
@@ -21,4 +21,13 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
     assert_equal 'search-test/Appointment?date=%3E2016-01-01&patient=test',
                  reply.request[:url]
   end
+
+  def test_url_encoded_form
+    stub_request(:post, /search-test/).to_return(body: '{"resourceType":"Bundle"}')
+    headers = client.fhir_headers(content_type: 'application/x-www-form-urlencoded')
+    payload = {test: "test-body"}
+    reply = client.send(:post, '/search-test', payload, headers)
+
+    assert_equal 'test=test-body', reply.request[:payload]
+  end
 end


### PR DESCRIPTION
The repository does not support content-type: x-www-form-urlencoded payloads.
This PR simply adds a branch to `request_payload` to support it.

Please let me know what you think.