### PR TITLE
Fix unknown exception.

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -433,7 +433,7 @@ module FHIR
         begin
           response = @client.get(url, headers: headers)
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "GET - Request: #{url} failed! No response from server: #{e}"
@@ -480,7 +480,7 @@ module FHIR
           @reply = FHIR::ClientReply.new(req, res, self)
           return @reply
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "GET - Request: #{url} failed! No response from server: #{e}"
@@ -515,7 +515,7 @@ module FHIR
         begin
           response = @client.post(url, headers: headers, body: payload)
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "POST - Request: #{url} failed! No response from server: #{e}"
@@ -562,7 +562,7 @@ module FHIR
         begin
           response = @client.put(url, headers: headers, body: payload)
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PUT - Request: #{url} failed! No response from server: #{e}"
@@ -609,7 +609,7 @@ module FHIR
         begin
           response = @client.patch(url, headers: headers, body: payload)
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PATCH - Request: #{url} failed! No response from server: #{e}"
@@ -645,7 +645,7 @@ module FHIR
             @reply = FHIR::ClientReply.new(request.args, res, self)
           end
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PATCH - Request: #{url} failed! No response from server: #{e}"
@@ -677,7 +677,7 @@ module FHIR
         begin
           response = @client.delete(url, headers: headers)
         rescue => e
-          unless e.response
+          unless e.respond_to? :response
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "DELETE - Request: #{url} failed! No response from server: #{e}"

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -433,7 +433,7 @@ module FHIR
         begin
           response = @client.get(url, headers: headers)
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "GET - Request: #{url} failed! No response from server: #{e}"
@@ -480,7 +480,7 @@ module FHIR
           @reply = FHIR::ClientReply.new(req, res, self)
           return @reply
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "GET - Request: #{url} failed! No response from server: #{e}"
@@ -515,7 +515,7 @@ module FHIR
         begin
           response = @client.post(url, headers: headers, body: payload)
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "POST - Request: #{url} failed! No response from server: #{e}"
@@ -562,7 +562,7 @@ module FHIR
         begin
           response = @client.put(url, headers: headers, body: payload)
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PUT - Request: #{url} failed! No response from server: #{e}"
@@ -609,7 +609,7 @@ module FHIR
         begin
           response = @client.patch(url, headers: headers, body: payload)
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PATCH - Request: #{url} failed! No response from server: #{e}"
@@ -645,7 +645,7 @@ module FHIR
             @reply = FHIR::ClientReply.new(request.args, res, self)
           end
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "PATCH - Request: #{url} failed! No response from server: #{e}"
@@ -677,7 +677,7 @@ module FHIR
         begin
           response = @client.delete(url, headers: headers)
         rescue => e
-          unless e.respond_to? :response
+          if !e.respond_to?(:response) || e.response.nil?
             # Re-raise the client error if there's no response. Otherwise, logging
             # and other things break below!
             FHIR.logger.error "DELETE - Request: #{url} failed! No response from server: #{e}"

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -66,10 +66,20 @@ class BasicTest < Test::Unit::TestCase
           client.send(method, stubbed_path, format_headers)
           assert_requested stub
         end
+        stub = stub_request(method, /basic-test/).to_raise(SocketError)
+        assert_raise(SocketError) do
+          client.send(method, stubbed_path, format_headers)
+          assert_requested stub
+        end
       end
       %i[post put patch].each do |method|
         stub = stub_request(method, /basic-test/).to_timeout
         assert_raise(RestClient::RequestTimeout, RestClient::Exceptions::OpenTimeout) do
+          client.send(method, stubbed_path, FHIR::Patient.new, format_headers)
+          assert_requested stub
+        end
+        stub = stub_request(method, /basic-test/).to_raise(SocketError)
+        assert_raise(SocketError) do
           client.send(method, stubbed_path, FHIR::Patient.new, format_headers)
           assert_requested stub
         end


### PR DESCRIPTION
Somewhere along the way, the client started not handling underlying exceptions properly, and masks the exception with its own exception instead of re-raising the origin exception.  This may have been due to a change in an underlying API, or Ruby itself.