### PR TITLE
Remove warn that is bad.

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -337,7 +337,6 @@ module FHIR
                 end
               end
         res.client = self unless res.nil?
-        FHIR.logger.warn "Expected #{klass} but got #{res.class}" if res.class != klass
       rescue => e
         FHIR.logger.error "Failed to parse #{format} as resource #{klass}: #{e.message}"
         res = nil

--- a/lib/fhir_client/version.rb
+++ b/lib/fhir_client/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   class Client
-    VERSION = '4.0.3'
+    VERSION = '4.0.4'
   end
 end


### PR DESCRIPTION
There is a warning that is common and incorrect.  For example, if you perform a search against the Patient resource, it warns that the result is not of type Patient, even though it most likely will be a Bundle (correctly). There are many cases where you expect a different resource type to be returned than the one you are making a query against.