### PR TITLE
updated search function to allow user to specify request headers

### DIFF
--- a/lib/fhir_client/sections/search.rb
+++ b/lib/fhir_client/sections/search.rb
@@ -29,7 +29,7 @@ module FHIR
         reply = if options[:search] && options[:search][:flag]
                   post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
                 else
-                  get resource_url(options), fhir_headers
+                  get resource_url(options), fhir_headers(headers)
                 end
         reply.resource = parse_reply(klass, format, reply)
         reply.resource_class = klass
@@ -41,7 +41,7 @@ module FHIR
         reply = if options[:search] && options[:search][:flag]
                   post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
                 else
-                  get resource_url(options), fhir_headers
+                  get resource_url(options), fhir_headers(headers)
                 end
         reply.resource = parse_reply(nil, format, reply)
         reply.resource_class = nil

--- a/lib/fhir_client/sections/search.rb
+++ b/lib/fhir_client/sections/search.rb
@@ -6,6 +6,7 @@ module FHIR
       #
       # @param klass The type of resource to be searched.
       # @param options A hash of options used to construct the search query.
+      # @param headers A hash of headers used in the http request itself. 
       # @return FHIR::ClientReply
       #
       def search(klass, options = {}, format = @default_format)


### PR DESCRIPTION
The FHIR specification allows for an FHIRVersion tag to be used in the content headers of requests, and which can change the return content: https://www.hl7.org/fhir/http.html#version-parameter

Currently, the search function doesn't allow the user to set headers for their http requests manually, so there is no way to modify it to include a version tag. This branch adds that functionality as an optional variable.

Note: because of the overlap with the commit that got rolled back, some of the changes don't show up in the git diff below. You can see the missing changes in the expanded file on lines:

12, 17-21, 28, 32-33, 42, 45-46