### PR TITLE
Ashankland changes

### DIFF
--- a/lib/fhir_client/sections/search.rb
+++ b/lib/fhir_client/sections/search.rb
@@ -6,6 +6,7 @@ module FHIR
       #
       # @param klass The type of resource to be searched.
       # @param options A hash of options used to construct the search query.
+      # @param headers A hash of headers used in the http request itself.
       # @return FHIR::ClientReply
       #
       def search(klass, options = {}, format = @default_format)
@@ -29,7 +30,7 @@ module FHIR
         reply = if options[:search] && options[:search][:flag]
                   post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
                 else
-                  get resource_url(options), fhir_headers
+                  get resource_url(options), fhir_headers(headers)
                 end
         reply.resource = parse_reply(klass, format, reply)
         reply.resource_class = klass
@@ -41,7 +42,7 @@ module FHIR
         reply = if options[:search] && options[:search][:flag]
                   post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
                 else
-                  get resource_url(options), fhir_headers
+                  get resource_url(options), fhir_headers(headers)
                 end
         reply.resource = parse_reply(nil, format, reply)
         reply.resource_class = nil

--- a/lib/fhir_client/sections/search.rb
+++ b/lib/fhir_client/sections/search.rb
@@ -1,3 +1,4 @@
+
 module FHIR
   module Sections
     module Search
@@ -9,14 +10,15 @@ module FHIR
       # @param headers A hash of headers used in the http request itself.
       # @return FHIR::ClientReply
       #
-      def search(klass, options = {}, format = @default_format)
+      def search(klass, options = {}, format = @default_format, headers = {})
         options[:resource] = klass
         options[:format] = format
 
         reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
+                  headers[:content_type] = 'application/x-www-form-urlencoded'
+                  post resource_url(options), nil, fhir_headers(headers)
                 else
-                  get resource_url(options), fhir_headers
+                  get resource_url(options), fhir_headers(headers)
                 end
         # reply = get resource_url(options), fhir_headers(options)
         reply.resource = parse_reply(klass, format, reply)
@@ -24,11 +26,12 @@ module FHIR
         reply
       end
 
-      def search_existing(klass, id, options = {}, format = @default_format)
+      def search_existing(klass, id, options = {}, format = @default_format, headers = {})
         options.merge!(resource: klass, id: id, format: format)
         # if options[:search][:flag]
         reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
+                  headers[:content_type] = 'application/x-www-form-urlencoded'
+                  post resource_url(options), nil, fhir_headers(headers)
                 else
                   get resource_url(options), fhir_headers(headers)
                 end
@@ -37,10 +40,11 @@ module FHIR
         reply
       end
 
-      def search_all(options = {}, format = @default_format)
+      def search_all(options = {}, format = @default_format, headers = {})
         options[:format] = format
         reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
+                  headers[:content_type] = 'application/x-www-form-urlencoded'
+                  post resource_url(options), nil, fhir_headers(headers)
                 else
                   get resource_url(options), fhir_headers(headers)
                 end


### PR DESCRIPTION
The FHIR specification allows for an FHIRVersion tag to be used in the content headers of requests, and which can change the return content: https://www.hl7.org/fhir/http.html#version-parameter

Currently, the search function doesn't allow the user to set headers for their http requests manually, so there is no way to modify it to include a version tag. This branch adds that functionality as an optional variable.

Note: this is a new copy of the pull request which doesn't omit any changes from the diff. 