### PR TITLE
`oauth2` Refresh Token Utilization

### DIFF
--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -428,7 +428,7 @@ module FHIR
       FHIR.logger.info "GETTING: #{url}"
       headers = clean_headers(headers) unless headers.empty?
       if @use_oauth2_auth
-        # @client.refresh!
+        refresh_oauth2_session
         begin
           response = @client.get(url, headers: headers)
         rescue => e
@@ -510,7 +510,7 @@ module FHIR
       headers = clean_headers(headers)
       payload = request_payload(resource, headers) if resource
       if @use_oauth2_auth
-        # @client.refresh!
+        refresh_oauth2_session
         begin
           response = @client.post(url, headers: headers, body: payload)
         rescue => e
@@ -557,7 +557,7 @@ module FHIR
       headers = clean_headers(headers)
       payload = request_payload(resource, headers) if resource
       if @use_oauth2_auth
-        # @client.refresh!
+        refresh_oauth2_session
         begin
           response = @client.put(url, headers: headers, body: payload)
         rescue => e
@@ -604,7 +604,7 @@ module FHIR
       headers = clean_headers(headers)
       payload = request_patch_payload(patchset, headers['Content-Type'])
       if @use_oauth2_auth
-        # @client.refresh!
+        refresh_oauth2_session
         begin
           response = @client.patch(url, headers: headers, body: payload)
         rescue => e
@@ -672,7 +672,7 @@ module FHIR
       FHIR.logger.info "DELETING: #{url}"
       headers = clean_headers(headers)
       if @use_oauth2_auth
-        # @client.refresh!
+        refresh_oauth2_session
         begin
           response = @client.delete(url, headers: headers)
         rescue => e
@@ -735,6 +735,13 @@ module FHIR
       else
         "#{base_path(path)}#{path}"
       end
+    end
+
+    private
+
+    def refresh_oauth2_session
+      return unless @use_oauth2_auth
+      @client = @client.refresh! if (@client.expired? && @client.refresh_token)
     end
   end
 end


### PR DESCRIPTION
The following PR allows for the leveraging of refresh tokens when using OAuth 2.0 authentication. If a refresh token is available, it will be utilized once the current access token has expired.

Given the [current best practices for SMART on FHIR EHRs ](http://docs.smarthealthit.org/authorization/best-practices/), this seems like it would be useful for anyone utilizing OAuth 2.0 in scenarios where you may have a persistent thread or long-running process (for example, a process taking incoming data from one system and importing it into another via the FHIR APIs).