### PR TITLE
Allow putting search params in post body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,14 @@ client.destroy(FHIR::Patient, patient_id)
 
 ### Searching
 ```ruby
+# via GET
 reply = client.search(FHIR::Patient, search: {parameters: {name: 'P'}})
+
+# via POST
+reply = client.search(FHIR::Patient, search: {body: {name: 'P'}})
+
 bundle = reply.resource
-patient = bundle.entry.first.resource
+patient = bundle&.entry&.first&.resource
 ```
 
 ### Fetching a Bundle

--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,9 @@
 require 'bundler/setup'
 require 'fhir_client'
 
+# Default to INFO because Debug level makes the console hard to use
+FHIR.logger.level = Logger::INFO
+
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 

--- a/bin/console
+++ b/bin/console
@@ -3,9 +3,6 @@
 require 'bundler/setup'
 require 'fhir_client'
 
-# Default to INFO because Debug level makes the console hard to use
-FHIR.logger.level = Logger::INFO
-
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -3,6 +3,11 @@ require 'fhir_dstu2_models'
 require 'fhir_stu3_models'
 require 'active_support/all'
 
+# Default to INFO level logging for all FHIR namespaced logging. Since there is
+# no single gem that 'owns' the FHIR namespace, we use the client as the spot
+# to set the default. Otherwise the default is set to DEBUG, which is too high.
+FHIR.logger.level = Logger::INFO
+
 root = File.expand_path '.', File.dirname(File.absolute_path(__FILE__))
 Dir.glob(File.join(root, 'fhir_client', 'sections', '**', '*.rb')).each do |file|
   require file

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -374,6 +374,7 @@ module FHIR
     end
 
     # Extract the request payload in the specified format, defaults to XML
+    # Note that the payload is usually a resource, but could be a form post for searches depending on content type
     def request_payload(resource, headers)
       if headers
         format_specified = headers['Content-Type']
@@ -383,6 +384,9 @@ module FHIR
           resource.to_xml
         elsif format_specified.downcase.include?('json')
           resource.to_json
+        elsif format_specified.downcase == 'application/x-www-form-urlencoded'
+          # special case where this is a search body and not a resource
+          resource
         else
           resource.to_xml
         end

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -385,7 +385,8 @@ module FHIR
         elsif format_specified.downcase.include?('json')
           resource.to_json
         elsif format_specified.downcase == 'application/x-www-form-urlencoded'
-          # special case where this is a search body and not a resource
+          # Special case where this is a search body and not a resource.
+          # Leave as hash because underlying libraries automatically URL encode it.
           resource
         else
           resource.to_xml

--- a/lib/fhir_client/sections/search.rb
+++ b/lib/fhir_client/sections/search.rb
@@ -12,40 +12,28 @@ module FHIR
         options[:resource] = klass
         options[:format] = format
 
-        reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
-                else
+        reply = if options.dig(:search, :flag).nil? && options.dig(:search, :body).nil?
                   get resource_url(options), fhir_headers
+                else
+                  options[:search][:flag] = true
+                  post resource_url(options), options.dig(:search, :body), fhir_headers({content_type: 'application/x-www-form-urlencoded'})
                 end
-        # reply = get resource_url(options), fhir_headers(options)
+
         reply.resource = parse_reply(klass, format, reply)
         reply.resource_class = klass
         reply
       end
 
+      # It does not appear that this is part of the specification (any more?)
+      # Investigate removing in next major version.
       def search_existing(klass, id, options = {}, format = @default_format)
-        options.merge!(resource: klass, id: id, format: format)
-        # if options[:search][:flag]
-        reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
-                else
-                  get resource_url(options), fhir_headers
-                end
-        reply.resource = parse_reply(klass, format, reply)
-        reply.resource_class = klass
-        reply
+        options[:id] = id
+        search(klass, options, format)
       end
 
       def search_all(options = {}, format = @default_format)
         options[:format] = format
-        reply = if options[:search] && options[:search][:flag]
-                  post resource_url(options), nil, fhir_headers({content_type: 'application/x-www-form-urlencoded'})
-                else
-                  get resource_url(options), fhir_headers
-                end
-        reply.resource = parse_reply(nil, format, reply)
-        reply.resource_class = nil
-        reply
+        search(nil, options, format)
       end
     end
   end

--- a/test/unit/client_interface_sections/search_test.rb
+++ b/test/unit/client_interface_sections/search_test.rb
@@ -7,7 +7,7 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
   def empty_search_response
     {
       headers: {
-        'Accept': 'application/fhir+json'
+        'Content-Type': 'application/fhir+json'
       },
       body: { resourceType: 'Bundle' }.to_json
     }

--- a/test/unit/client_interface_sections/search_test.rb
+++ b/test/unit/client_interface_sections/search_test.rb
@@ -1,13 +1,21 @@
 require_relative '../../test_helper'
 
 class ClientInterfaceSearchTest < Test::Unit::TestCase
-  def client
-    @client ||= FHIR::Client.new("search-test")
+  def setup
+    @client = FHIR::Client.new("http://search-test")
+  end
+  def empty_search_response
+    {
+      headers: {
+        'Accept': 'application/fhir+json'
+      },
+      body: { resourceType: 'Bundle' }.to_json
+    }
   end
 
   def test_url_encoding_only_happens_once
-    stub_request(:get, /search-test/).to_return(body: '{"resourceType":"Bundle"}')
-    reply = client.search(
+    stub_request(:get, /search-test/).to_return(empty_search_response)
+    reply = @client.search(
       FHIR::Appointment,
       {
         search: {
@@ -18,7 +26,137 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-    assert_equal 'search-test/Appointment?date=%3E2016-01-01&patient=test',
+    assert_equal 'http://search-test/Appointment?date=%3E2016-01-01&patient=test',
                  reply.request[:url]
   end
+
+  def test_get_search
+    stub_request(:get, 'http://search-test/Patient?address=123%20Sesame%20Street&given=name').
+      to_return(empty_search_response)
+
+    reply = @client.search(
+      FHIR::Patient,
+      {
+        search: {
+          parameters: {
+            given: 'name',
+            address: '123 Sesame Street'
+          }
+        }
+      }
+    )
+    assert_equal 'http://search-test/Patient?address=123%20Sesame%20Street&given=name',
+                 reply.request[:url]
+  end
+  def test_post_search
+    search_body = {
+            given: 'name',
+            address: '123 Sesame Street'
+          }
+
+    # Stub this request in a slightly more difficult manner to completely ensure that requests
+    # contain encoded bodies and there isn't magic obscuring the fact that we are not.
+    stub_request(:post, 'http://search-test/Patient/_search').
+      with do |request|
+        ['address=123+Sesame+Street&given=name', 'given=name&address=123+Sesame+Street'].include?(request.body) &&
+        request.headers['Content-Type'] == 'application/x-www-form-urlencoded'
+      end.to_return(empty_search_response)
+
+    reply = @client.search(
+      FHIR::Patient,
+      {
+        search: {
+          body: search_body
+        }
+      }
+    )
+
+    assert_equal 'http://search-test/Patient/_search', reply.request[:url]
+  end
+
+  def test_post_search_no_body
+    stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street&given=name').
+      with(headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }).
+      to_return(empty_search_response)
+
+    reply = @client.search(
+      FHIR::Patient,
+      {
+        search: {
+          parameters: {
+            given: 'name',
+            address: '123 Sesame Street'
+          },
+          flag: true
+        }
+      }
+    )
+
+    assert_equal 'http://search-test/Patient/_search?address=123%20Sesame%20Street&given=name',
+                 reply.request[:url]
+
+  end
+
+  def test_post_search_body_and_params
+    stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street').
+      with(body: {given: 'name'}, headers: {"Content-Type" => 'application/x-www-form-urlencoded'}).
+      to_return(empty_search_response)
+
+    reply = @client.search(
+      FHIR::Patient,
+      {
+        search: {
+          body: {
+            given: 'name'
+          },
+          parameters: {
+            address: '123 Sesame Street'
+          }
+        }
+      }
+    )
+
+    assert_equal 'http://search-test/Patient/_search?address=123%20Sesame%20Street',
+                 reply.request[:url]
+  end
+
+  # It does not appear that this is still in the specification (if it ever was)
+  # Investigate removing.  Keeping test until code is removed.
+  def test_get_search_existing
+    stub_request(:get, 'http://search-test/Patient/1?address=123%20Sesame%20Street&given=name').
+      to_return(empty_search_response)
+
+    reply = @client.search_existing(
+      FHIR::Patient, 1,
+      {
+        search: {
+          parameters: {
+            given: 'name',
+            address: '123 Sesame Street'
+          }
+        }
+      }
+    )
+    assert_equal 'http://search-test/Patient/1?address=123%20Sesame%20Street&given=name',
+                 reply.request[:url]
+  end
+
+  def test_get_search_all
+    stub_request(:get, 'http://search-test/?address=123%20Sesame%20Street&given=name').
+      to_return(empty_search_response)
+
+    reply = @client.search_all(
+      {
+        search: {
+          parameters: {
+            given: 'name',
+            address: '123 Sesame Street'
+          }
+        }
+      }
+    )
+    assert_equal 'http://search-test/?address=123%20Sesame%20Street&given=name',
+                 reply.request[:url]
+  end
+
 end

--- a/test/unit/client_interface_sections/search_test.rb
+++ b/test/unit/client_interface_sections/search_test.rb
@@ -31,7 +31,7 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
   end
 
   def test_get_search
-    stub_request(:get, 'http://search-test/Patient?address=123%20Sesame%20Street&given=name').
+    search_response = stub_request(:get, 'http://search-test/Patient?address=123%20Sesame%20Street&given=name').
       to_return(empty_search_response)
 
     reply = @client.search(
@@ -45,8 +45,7 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-    assert_equal 'http://search-test/Patient?address=123%20Sesame%20Street&given=name',
-                 reply.request[:url]
+    assert_requested(search_response)
   end
   def test_post_search
     search_body = {
@@ -56,7 +55,7 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
 
     # Stub this request in a slightly more difficult manner to completely ensure that requests
     # contain encoded bodies and there isn't magic obscuring the fact that we are not.
-    stub_request(:post, 'http://search-test/Patient/_search').
+    search_response = stub_request(:post, 'http://search-test/Patient/_search').
       with do |request|
         ['address=123+Sesame+Street&given=name', 'given=name&address=123+Sesame+Street'].include?(request.body) &&
         request.headers['Content-Type'] == 'application/x-www-form-urlencoded'
@@ -70,12 +69,11 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-
-    assert_equal 'http://search-test/Patient/_search', reply.request[:url]
+    assert_requested(search_response)
   end
 
   def test_post_search_no_body
-    stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street&given=name').
+    search_response = stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street&given=name').
       with(headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }).
       to_return(empty_search_response)
 
@@ -91,14 +89,11 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-
-    assert_equal 'http://search-test/Patient/_search?address=123%20Sesame%20Street&given=name',
-                 reply.request[:url]
-
+    assert_requested(search_response)
   end
 
   def test_post_search_body_and_params
-    stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street').
+    search_response = stub_request(:post, 'http://search-test/Patient/_search?address=123%20Sesame%20Street').
       with(body: {given: 'name'}, headers: {"Content-Type" => 'application/x-www-form-urlencoded'}).
       to_return(empty_search_response)
 
@@ -115,15 +110,13 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-
-    assert_equal 'http://search-test/Patient/_search?address=123%20Sesame%20Street',
-                 reply.request[:url]
+    assert_requested(search_response)
   end
 
   # It does not appear that this is still in the specification (if it ever was)
   # Investigate removing.  Keeping test until code is removed.
   def test_get_search_existing
-    stub_request(:get, 'http://search-test/Patient/1?address=123%20Sesame%20Street&given=name').
+    search_response = stub_request(:get, 'http://search-test/Patient/1?address=123%20Sesame%20Street&given=name').
       to_return(empty_search_response)
 
     reply = @client.search_existing(
@@ -137,12 +130,11 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-    assert_equal 'http://search-test/Patient/1?address=123%20Sesame%20Street&given=name',
-                 reply.request[:url]
+    assert_requested(search_response)
   end
 
   def test_get_search_all
-    stub_request(:get, 'http://search-test/?address=123%20Sesame%20Street&given=name').
+    search_response = stub_request(:get, 'http://search-test/?address=123%20Sesame%20Street&given=name').
       to_return(empty_search_response)
 
     reply = @client.search_all(
@@ -155,8 +147,7 @@ class ClientInterfaceSearchTest < Test::Unit::TestCase
         }
       }
     )
-    assert_equal 'http://search-test/?address=123%20Sesame%20Street&given=name',
-                 reply.request[:url]
+    assert_requested(search_response)
   end
 
 end


### PR DESCRIPTION
The FHIR specification requires servers that support searching to support via GET or POST. While we did include the strangely named option `flag` that switched the request from a GET to a POST, we did not allow any manner to fill the body with the parameters.

This PR allows the user to pass a 'body' search option, which will automatically get encoded and put into the body.  If the user passes a `body`, it will automatically switch the request method to POST.  You may still pass `parameters` if you would like to pass the query string still, because that is allowed.

This PR includes tests for this, as well as tests for some other previously untested search methods.  However, we should revisit those search methods and probably remove them as they do not appear to be in the FHIR specification anymore.

You can try it out via the console:
```
bundle exec rake fhir:console
client = FHIR::Client.new('https://inferno.healthit.gov/reference-server/r4')
client.additional_headers = {Authorization: 'Bearer SAMPLE_TOKEN'}

# search by regular get
client.search(FHIR::Patient, {search: {parameters: {name: 'Lucien408'}}}).request

# search by post, with params in body
client.search(FHIR::Patient, {search: {body: {name: 'Lucien408'}}}).request

# search by post with some params in querystring, and some in body
client.search(FHIR::Patient, {search: {body: {birthdate: '1940-03-29'}, parameters: {name: 'Lucien408'}}}).request

# search by post with all params in querystring
# (this is the legacy method, which I think we should just get rid of, or at least rename)
client.search(FHIR::Patient, {search: {flag: true, parameters: {name: 'Lucien408'}}}).request
```
I considered having 'flag' determine whether to stuff the 'parameters' in the 'body' or 'querystring', but decided against it because it would require a major version update to our API to be nice, plus it is legal to split the search values between the querystring and the body so we should allow some method to do that.

This addresses the issue that was at the root of PR #125, though with a different implementation.