### PR TITLE
FI-1305: Use local client

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,8 +19,4 @@ task :rubocop do
   RuboCop::RakeTask.new
 end
 
-task :test do
-  system('open coverage/index.html')
-end
-
 task default: [:test]

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.3'
-  spec.add_dependency 'fhir_models', '>= 4.0.2'
-  spec.add_dependency 'fhir_stu3_models', '>= 3.0.1'
-  spec.add_dependency 'fhir_dstu2_models', '>= 1.0.10'
+  spec.add_dependency 'fhir_models', '>= 4.2.0'
+  spec.add_dependency 'fhir_stu3_models', '>= 3.1.0'
+  spec.add_dependency 'fhir_dstu2_models', '>= 1.1.0'
   spec.add_dependency 'nokogiri', '>= 1.10.4'
   spec.add_dependency 'oauth2', '~> 1.1'
   spec.add_dependency 'rack', '>= 1.5'

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -345,8 +345,10 @@ module FHIR
     end
 
     def set_client_on_resource(resource)
+      return if resource.nil?
+
       resource.client = self
-      resource.each_element do |element, _, path|
+      resource.each_element do |element, _, _|
         element.client = self if element.is_a?(Reference) || element.respond_to?(:resourceType)
       end
     end

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -315,33 +315,40 @@ module FHIR
     def parse_reply(klass, format, response)
       FHIR.logger.debug "Parsing response with {klass: #{klass}, format: #{format}, code: #{response.code}}."
       return nil unless [200, 201].include? response.code
-      res = nil
-      begin
-        res = if(@fhir_version == :dstu2 || klass&.ancestors&.include?(FHIR::DSTU2::Model))
-                if(format.include?('xml'))
-                  FHIR::DSTU2::Xml.from_xml(response.body)
-                else
-                  FHIR::DSTU2::Json.from_json(response.body)
-                end
-              elsif(@fhir_version == :r4 || klass&.ancestors&.include?(FHIR::Model))
-                if(format.include?('xml'))
-                  FHIR::Xml.from_xml(response.body)
-                else
-                  FHIR::Json.from_json(response.body)
-                end
-              else
-                if(format.include?('xml'))
-                  FHIR::STU3::Xml.from_xml(response.body)
-                else
-                  FHIR::STU3::Json.from_json(response.body)
-                end
-              end
-        res.client = self unless res.nil?
-      rescue => e
-        FHIR.logger.error "Failed to parse #{format} as resource #{klass}: #{e.message}"
-        res = nil
-      end
+      res =
+        begin
+          if(@fhir_version == :dstu2 || klass&.ancestors&.include?(FHIR::DSTU2::Model))
+            if(format.include?('xml'))
+              FHIR::DSTU2::Xml.from_xml(response.body)
+            else
+              FHIR::DSTU2::Json.from_json(response.body)
+            end
+          elsif(@fhir_version == :r4 || klass&.ancestors&.include?(FHIR::Model))
+            if(format.include?('xml'))
+              FHIR::Xml.from_xml(response.body)
+            else
+              FHIR::Json.from_json(response.body)
+            end
+          else
+            if(format.include?('xml'))
+              FHIR::STU3::Xml.from_xml(response.body)
+            else
+              FHIR::STU3::Json.from_json(response.body)
+            end
+          end
+        rescue => e
+          FHIR.logger.error "Failed to parse #{format} as resource #{klass}: #{e.message}"
+          nil
+        end
+      set_client_on_resource(res) unless res.nil?
       res
+    end
+
+    def set_client_on_resource(resource)
+      resource.client = self
+      resource.each_element do |element, _, _|
+        element.client = self if element.is_a? Reference
+      end
     end
 
     def strip_base(path)

--- a/lib/fhir_client/client.rb
+++ b/lib/fhir_client/client.rb
@@ -346,8 +346,8 @@ module FHIR
 
     def set_client_on_resource(resource)
       resource.client = self
-      resource.each_element do |element, _, _|
-        element.client = self if element.is_a? Reference
+      resource.each_element do |element, _, path|
+        element.client = self if element.is_a?(Reference) || element.respond_to?(:resourceType)
       end
     end
 

--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -2,17 +2,14 @@ module FHIR
   module ModelExtras
 
     def self.included base
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
       base.extend ClassMethods
+      base.attr_writer :client
     end
 
     module InstanceMethods
       def client
-        FHIR::Model.client
-      end
-
-      def client=(client)
-        FHIR::Model.client = client
+        @client || FHIR::Model.client
       end
 
       def vread(version_id)

--- a/lib/fhir_client/sections/crud.rb
+++ b/lib/fhir_client/sections/crud.rb
@@ -226,7 +226,7 @@ module FHIR
           resource.id = FHIR::ResourceAddress.pull_out_id(resource.class.name.demodulize, reply.self_link)
           reply.resource = resource # just send back the submitted resource
         end
-        reply.resource.client = self
+        set_client_on_resource(reply.resource)
         reply.resource_class = resource.class
         reply
       end

--- a/lib/fhir_client/sections/operations.rb
+++ b/lib/fhir_client/sections/operations.rb
@@ -132,8 +132,11 @@ module FHIR
         add_resource_parameter(params, 'resource', resource)
         add_parameter(params, 'onlyCertainMatches', 'Boolean', options[:onlyCertainMatches]) unless options[:onlyCertainMatches].nil?
         add_parameter(params, 'count', 'Integer', options[:matchCount]) if options[:matchCount].is_a?(Integer)
-        post resource_url(options), params, fhir_headers({content_type: "#{format || @default_format}",
-                                                          accept: "#{format || @default_format}"})
+        post(
+          resource_url(options),
+          params,
+          fhir_headers({content_type: "#{format || @default_format}", accept: "#{format || @default_format}"})
+        ).tap { |reply| set_client_on_resource(reply.resource) }
       end
 
       #
@@ -154,7 +157,8 @@ module FHIR
         params = versioned_resource_class('Parameters').new
         add_resource_parameter(params, 'resource', resource)
         add_parameter(params, 'profile', 'Uri', options[:profile_uri]) unless options[:profile_uri].nil?
-        post resource_url(options), params, fhir_headers(headers)
+        post(resource_url(options), params, fhir_headers(headers))
+          .tap { |reply| set_client_on_resource(reply.resource) }
       end
 
       def validate_existing(resource, id, options = {}, format = @default_format)
@@ -165,7 +169,8 @@ module FHIR
         params = versioned_resource_class('Parameters').new
         add_resource_parameter(params, 'resource', resource)
         add_parameter(params, 'profile', 'Uri', options[:profile_uri]) unless options[:profile_uri].nil?
-        post resource_url(options), params, fhir_headers(headers)
+        post(resource_url(options), params, fhir_headers(headers))
+          .tap { |reply| set_client_on_resource(reply.resource) }
       end
 
       private

--- a/lib/fhir_client/sections/transactions.rb
+++ b/lib/fhir_client/sections/transactions.rb
@@ -74,6 +74,7 @@ module FHIR
         rescue
           reply.resource = nil
         end
+        set_client_on_resource(reply.resource)
         reply.resource_class = reply.resource.class
         reply
       end

--- a/lib/fhir_client/version.rb
+++ b/lib/fhir_client/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   class Client
-    VERSION = '4.0.6'.freeze
+    VERSION = '5.0.0'.freeze
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,9 @@ require 'test/unit'
 require 'webmock/test_unit'
 
 require 'fhir_client'
-FHIR.logger.level = Logger::ERROR
+FHIR.logger = Logger.new('/dev/null')
+FHIR::STU3.logger = Logger.new('/dev/null')
+FHIR::DSTU2.logger = Logger.new('/dev/null')
 
 ACCEPT_REGEX_XML = /^(\s*application\/fhir\+xml\s*)(;\s*charset\s*=\s*utf-8\s*)?$/
 ACCEPT_REGEX_JSON = /^(\s*application\/fhir\+json\s*)(;\s*charset\s*=\s*utf-8\s*)?$/

--- a/test/unit/reference_extras_test.rb
+++ b/test/unit/reference_extras_test.rb
@@ -148,4 +148,17 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert res.nil?
   end
 
+  def test_reference_read_client
+    reference_client = FHIR::Client.new('reference')
+    model_client = FHIR::Client.new('model')
+
+    ref = FHIR::Reference.new({'reference': 'Patient/foo'})
+    ref.client = reference_client
+    FHIR::Model.client = model_client
+
+    request = stub_request(:get, /reference/)
+    ref.read
+
+    assert_requested(request)
+  end
 end


### PR DESCRIPTION
Resources (and the references and other resources they contain) now store their own client instances rather than relying on a global `FHIR::Model.client`.