### PR TITLE
Added the ability to specify the client when using the partial_update method

### DIFF
--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -104,7 +104,7 @@ module FHIR
         handle_response client.exception_class, client.conditional_create(model, params)
       end
 
-      def partial_update(id, patchset, options = {})
+      def partial_update(id, patchset, options = {}, client = self.client)
         handle_response client.exception_class, client.partial_update(self, id, patchset, options)
       end
 

--- a/test/unit/client_interface_sections/update_test.rb
+++ b/test/unit/client_interface_sections/update_test.rb
@@ -30,7 +30,7 @@ class ClientInterfaceUpdateTest < Test::Unit::TestCase
     outcome = FHIR::OperationOutcome.new({'issue'=>[{'code'=>'informational', 'severity'=>'information', 'diagnostics'=>'Successfully updated "Patient/foo" in 0 ms'}]})
 
     stub_request(:patch, /Patient\/foo/).with(body: "[{\"op\":\"replace\",\"path\":\"/active/\",\"value\":\"false\"}]").to_return(status: 200, body: outcome.to_json, headers: {'Content-Type'=>'application/fhir+json', 'Location'=>'http://update-test/Patient/foo/_history/0', 'ETag'=>'W/"foo"', 'Last-Modified'=>Time.now.strftime("%a, %e %b %Y %T %Z")})
-    reply = FHIR::Patient.partial_update(patient.id, patchset)
+    reply = FHIR::Patient.partial_update(patient.id, patchset, {}, client)
     assert reply.is_a?(FHIR::DSTU2::OperationOutcome)
   end
 


### PR DESCRIPTION
All but `partial_update` `FHIR::ModelExtras::ClassMethods` methods have the `client` attribute.

In this PR I suggest adding it in order to have the same interface for all those methods.

I did not want to introduce a breaking change so the `client` param is added at the end.

What do you think?

(I'll fix the specs once the API is OK with the mainteners)