### PR TITLE
FI-1400: Allow custom client for reference resolution

### DIFF
--- a/lib/fhir_client/ext/reference.rb
+++ b/lib/fhir_client/ext/reference.rb
@@ -54,7 +54,7 @@ module FHIR
       parts[:base_uri]
     end
 
-    def read
+    def read(client = self.client)
       return if !(relative? || absolute?)
       if relative? || reference == client.full_resource_url(resource: resource_class, id: reference_id)
         read_client = client
@@ -64,7 +64,7 @@ module FHIR
       resource_class.read(reference_id, read_client)
     end
 
-    def vread
+    def vread(client = self.client)
       return if !(relative? || absolute?) || version_id.blank?
       if relative? || reference == client.full_resource_url(resource: resource_class, id: reference_id)
         read_client = client

--- a/test/unit/reference_extras_test.rb
+++ b/test/unit/reference_extras_test.rb
@@ -161,4 +161,30 @@ class ReferencesExtrasTest < Test::Unit::TestCase
 
     assert_requested(request)
   end
+
+  def test_reference_read_optional_client
+    reference_client = FHIR::Client.new('reference')
+    custom_client = FHIR::Client.new('custom')
+
+    ref = FHIR::Reference.new({'reference': 'Patient/foo'})
+    ref.client = reference_client
+
+    request = stub_request(:get, /custom/)
+    ref.read(custom_client)
+
+    assert_requested(request)
+  end
+
+  def test_reference_vread_optional_client
+    reference_client = FHIR::Client.new('reference')
+    custom_client = FHIR::Client.new('custom')
+
+    ref = FHIR::Reference.new({'reference': 'Patient/foo/_history/1'})
+    ref.client = reference_client
+
+    request = stub_request(:get, /custom/)
+    ref.vread(custom_client)
+
+    assert_requested(request)
+  end
 end


### PR DESCRIPTION
This branch lets you do `reference.read(client)` to use a specific FHIR client to resolve a reference.