### PR TITLE
OAuth2 2.x

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,5 @@
 require 'simplecov'
 SimpleCov.command_name 'Unit Tests'
-SimpleCov.start do
-  add_filter "test/"
-  add_group "Library", "lib"
-end
 
 class SimpleCov::Formatter::QualityFormatter
   def format(result)

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.10.4'
-  spec.add_dependency 'oauth2', '~> 1.1'
+  spec.add_dependency 'oauth2', '>= 1.1'
   spec.add_dependency 'rack', '>= 1.5'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'simplecov'
-SimpleCov.start
-
+SimpleCov.start do
+  add_filter "test/"
+  add_group "Library", "lib"
+end
 require 'pry'
 require 'test/unit'
 require 'webmock/test_unit'


### PR DESCRIPTION
OAuth2 1.x is EOL (#152)

This PR is about enabling OAuth2 2.x
Here is the changelog with the breaking changes: https://gitlab.com/oauth-xx/oauth2/-/blob/v2.0.9/CHANGELOG.md#changed-3

Reading the code of this gem I don't think it will be an issue (+ the test suite remains green)

PS: I had to fix an issue when running the test suite with `bundle exec rake`
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/639743/204996324-b862b102-4a06-4ccd-9c5a-4b68a30be204.png">
