### PR TITLE
Add Ruby 3.0, 3.1, and 3.2 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,5 +23,15 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,11 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7', '2.6']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
+require:
+  - rubocop-performance
+
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - '*.gemspec'
     - 'Gemfile*'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rubocop', '~> 0.52.1', require: false
+  gem 'rubocop', '~> 1.0', require: false
+  gem 'rubocop-performance', require: false
   gem 'awesome_print', require: 'ap'
 end

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -9,10 +9,10 @@ require 'active_support/all'
 FHIR.logger.level = Logger::INFO
 
 root = File.expand_path '.', File.dirname(File.absolute_path(__FILE__))
-Dir.glob(File.join(root, 'fhir_client', 'sections', '**', '*.rb')).each do |file|
+Dir.glob(File.join(root, 'fhir_client', 'sections', '**', '*.rb')).sort.each do |file|
   require file
 end
-Dir.glob(File.join(root, 'fhir_client', 'ext', '**', '*.rb')).each do |file|
+Dir.glob(File.join(root, 'fhir_client', 'ext', '**', '*.rb')).sort.each do |file|
   require file
 end
 
@@ -25,6 +25,6 @@ require_relative 'fhir_client/patch_format'
 require_relative 'fhir_client/client_exception'
 require_relative 'fhir_client/version'
 
-Dir.glob(File.join(root, 'fhir_client', 'model', '**', '*.rb')).each do |file|
+Dir.glob(File.join(root, 'fhir_client', 'model', '**', '*.rb')).sort.each do |file|
   require file
 end

--- a/lib/fhir_client/ext/bundle.rb
+++ b/lib/fhir_client/ext/bundle.rb
@@ -1,23 +1,23 @@
 module FHIR
   module BundleExtras
     def self_link
-      link.select { |n| n.relation == 'self' }.first
+      link.find { |n| n.relation == 'self' }
     end
 
     def first_link
-      link.select { |n| n.relation == 'first' }.first
+      link.find { |n| n.relation == 'first' }
     end
 
     def last_link
-      link.select { |n| n.relation == 'last' }.first
+      link.find { |n| n.relation == 'last' }
     end
 
     def next_link
-      link.select { |n| n.relation == 'next' }.first
+      link.find { |n| n.relation == 'next' }
     end
 
     def previous_link
-      link.select { |n| n.relation == 'previous' || n.relation == 'prev' }.first
+      link.find { |n| n.relation == 'previous' || n.relation == 'prev' }
     end
 
     def get_by_id(id)


### PR DESCRIPTION
Getting this to green required a little bit of work.  In addition to adding these entries to the matrix the following changes were made:

1. Updated actions/checkout to v3.
2. Changed the rubocop version restriction to `~> 1.0`
3. Split out Rubocop so it only runs once as part of CI
4. Updated the Rubocop minimum Ruby target version to 2.6 to match CI
5. Added rubocop-performance to support extracted rubocop-performance cop
6. Fixed a few lints.

Runs green on my fork.