### PR TITLE
FI-3474 Add check if resource_type is nil

### DIFF
--- a/lib/fhir_client/ext/reference.rb
+++ b/lib/fhir_client/ext/reference.rb
@@ -82,7 +82,7 @@ module FHIR
     include FHIR::ReferenceExtras
 
     def resource_class
-      FHIR.const_get(resource_type) unless contained?
+      FHIR.const_get(resource_type) unless contained? || resource_type.nil?
     end
   end
 end
@@ -101,7 +101,7 @@ end
 
 module FHIR
   module STU3
-    class Reference 
+    class Reference
       include FHIR::ReferenceExtras
 
       def resource_class

--- a/test/unit/reference_extras_test.rb
+++ b/test/unit/reference_extras_test.rb
@@ -62,6 +62,11 @@ class ReferencesExtrasTest < Test::Unit::TestCase
     assert r.resource_class == FHIR::DSTU2::Patient
   end
 
+  def test_reference_klass_empty
+    r = FHIR::Reference.new({'display': 'abc'})
+    assert r.resource_class.nil?
+  end
+
   def test_relative
     r = FHIR::Reference.new({'reference': 'Patient/foo'})
     assert r.relative?


### PR DESCRIPTION
This fix GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/589

Root cause for this issue is that `resource_class` crashed if `reference` and then `resource_type` is empty.

Solution:

Add a check if `resource_type` is `nil` then return `nil`

