### PR TITLE
Gemspec updates and Ruby update

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'parallel', '1.26.3'
-
 group :test do
   gem 'rubocop', '~> 1.86', require: false
+  gem 'parallel', '1.26.3'
   gem 'awesome_print', require: 'ap'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'parallel', '1.26.3'
+
 group :test do
-  gem 'rubocop', '~> 1.23.0', require: false
+  gem 'rubocop', '~> 1.86', require: false
   gem 'awesome_print', require: 'ap'
 end

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.19.1'
   spec.add_dependency 'oauth2', '~> 2.0'
-  spec.add_dependency 'rack', '>= 3.2.6'
+  spec.add_dependency 'rack', '>= 2.0'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'
 

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.19.1'
   spec.add_dependency 'oauth2', '~> 2.0'
-  spec.add_dependency 'rack', '>= 2.0'
+  spec.add_dependency 'rack', '>= 2.2'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'
 

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.19.1'
   spec.add_dependency 'oauth2', '~> 2.0'
-  spec.add_dependency 'rack', '>= 2.20'
+  spec.add_dependency 'rack', '>= 2.2.23'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'
 

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.19.1'
   spec.add_dependency 'oauth2', '~> 2.0'
-  spec.add_dependency 'rack', '>= 2.2'
+  spec.add_dependency 'rack', '>= 2.20'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'
 

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.9.0'
-  spec.add_dependency 'fhir_models', '>= 5.0.0'
+  spec.add_dependency 'fhir_models', '>= 5.1.0'
   spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.19.1'

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -21,15 +21,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.3.6'
   spec.add_dependency 'activesupport', '>= 3'
-  spec.add_dependency 'addressable', '>= 2.3'
+  spec.add_dependency 'addressable', '>= 2.9.0'
   spec.add_dependency 'fhir_models', '>= 5.0.0'
   spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
   spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
-  spec.add_dependency 'nokogiri', '>= 1.10.4'
+  spec.add_dependency 'nokogiri', '>= 1.19.1'
   spec.add_dependency 'oauth2', '~> 2.0'
-  spec.add_dependency 'rack', '>= 1.5'
+  spec.add_dependency 'rack', '>= 3.2.6'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'tilt', '>= 1.1'
 

--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.3.6'
+  spec.required_ruby_version = '>= 3.0.0'
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.9.0'
   spec.add_dependency 'fhir_models', '>= 5.0.0'


### PR DESCRIPTION
# Summary
- Ruby update to 3.3.6
- Nokogiri bumped to 1.19.1
- Rubocop bumped to 1.86
- addressable bumped to 2.9.0 (latest version)
- rack bumped to 3.2.6 (latest version) 
- parallel regressed to 1.26.3 to match inferno-core and to be able to support ruby 3.2 

No rubocop offenses detected locally after updating specs